### PR TITLE
[Botskills] Change from warning to informative message

### DIFF
--- a/tools/botskills/src/utils/authenticationUtils.ts
+++ b/tools/botskills/src/utils/authenticationUtils.ts
@@ -108,7 +108,7 @@ export class AuthenticationUtils {
         try {
             // configuring bot auth settings
             logger.message('Checking for authentication settings ...');
-            if (manifest.authenticationConnections) {
+            if (manifest.authenticationConnections && manifest.authenticationConnections.length > 0) {
                 const aadConfig: IAuthenticationConnection | undefined = manifest.authenticationConnections.find(
                     (connection: IAuthenticationConnection) => connection.serviceProviderId === 'Azure Active Directory v2');
                 if (aadConfig) {
@@ -247,13 +247,15 @@ export class AuthenticationUtils {
 
                     logger.message('Authentication process finished successfully.');
 
-                    return true;
                 } else {
                     throw new Error(`There's no Azure Active Directory v2 authentication connection in your Skills manifest.`);
                 }
             } else {
-                throw new Error(`There are no authentication connections in your Skills manifest.`);
+                logger.message(`There are no authentication connections in your Skills manifest.`);
             }
+
+            return true;
+
         } catch (err) {
             logger.warning(`Could not configure authentication connection automatically.`);
             if (currentCommand.length > 0) {

--- a/tools/botskills/test/authentication.test.js
+++ b/tools/botskills/test/authentication.test.js
@@ -110,8 +110,8 @@ describe("The authentication util", function() {
 
             await authenticationUtils.authenticate(configuration, require(configuration.localManifest), configuration.logger);
 
-            const warningList = configuration.logger.getWarning();
-            strictEqual(warningList[warningList.length - 1], `There are no authentication connections in your Skills manifest.`);
+            const messageList = configuration.logger.getMessage();
+            strictEqual(messageList[messageList.length - 1], `There are no authentication connections in your Skills manifest.`);
         });
 
         it("when the skill manifest doesn't contain an Azure Active Directory v2 as authentication connection", async function() {


### PR DESCRIPTION
## Purpose
_What is the context of this pull request? Why is it being done?_
The user may be confused by the warning message when there are no authentication connections to configure during the Skill connection.

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_
Replace the warning if there are no authentication connections to an informative message. The initial condition was also modified to contemplate the cases of an empty array.

![image](https://user-images.githubusercontent.com/40918752/65537573-d8eb1580-dedb-11e9-88ab-b6b9b3865e5e.png)

## Tests
_Is this covered by existing tests or new ones? If no, why not?_
`authentication.test.js` covers the changes that are being added.
### Testing Steps
1. Deploy a `Virtual Assistant` and `Skill`.
2. Go to `.\templates\Virtual-Assistant-Template\typescript\samples\sample-assistant`.
3. Open a terminal in that location and establish a connection between the `Virtual Assistant` and `Skill`, make sure to make a connection without authentication, by having an empty array in the `authenticationConnections` file `manifestTemplate.json`.
4. Check that the image matches.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist
#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
