### PR TITLE
[TypeScript][BotBuilder-Solutions] ContentModeratorMiddleware parity with C#

### DIFF
--- a/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
@@ -37,7 +37,7 @@ export class ContentModeratorMiddleware implements Middleware {
         if (region === undefined) throw new Error(`Parameter 'region' cannot be undefined.`);
 
         this.subscriptionKey = subscriptionKey;
-        this.region = region.startsWith('https://') ? region : `https://${ region }`.concat('.api.cognitive.microsoft.com');
+        this.region = (region.startsWith('https://') ? region : `https://${ region }`).concat('.api.cognitive.microsoft.com');
     }
 
     /**

--- a/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
@@ -33,13 +33,8 @@ export class ContentModeratorMiddleware implements Middleware {
      * @param region Azure Service Region.
      */
     public constructor(subscriptionKey: string, region: string) {
-        if (subscriptionKey === undefined) {
-            throw new Error(`Parameter 'subscriptionKey' cannot be undefined.`);
-        }
-
-        if (region === undefined) {
-            throw new Error(`Parameter 'region' cannot be undefined.`);
-        }
+        if (subscriptionKey === undefined) throw new Error(`Parameter 'subscriptionKey' cannot be undefined.`);
+        if (region === undefined) throw new Error(`Parameter 'region' cannot be undefined.`);
 
         this.subscriptionKey = subscriptionKey;
         this.region = region.startsWith('https://') ? region : `https://${ region }`.concat('.api.cognitive.microsoft.com');

--- a/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
@@ -33,8 +33,16 @@ export class ContentModeratorMiddleware implements Middleware {
      * @param region Azure Service Region.
      */
     public constructor(subscriptionKey: string, region: string) {
+        if (subscriptionKey === undefined) {
+            throw new Error(`Parameter 'subscriptionKey' cannot be undefined.`);
+        }
+
+        if (region === undefined) {
+            throw new Error(`Parameter 'region' cannot be undefined.`);
+        }
+
         this.subscriptionKey = subscriptionKey;
-        this.region = region;
+        this.region = region.startsWith('https://') ? region : `https://${ region }`.concat('.api.cognitive.microsoft.com');
     }
 
     /**
@@ -51,7 +59,7 @@ export class ContentModeratorMiddleware implements Middleware {
             const textStream: Readable = this.textToReadable(context.activity.text);
 
             const credentials: CognitiveServicesCredentials = new CognitiveServicesCredentials(this.subscriptionKey);
-            const client: ContentModeratorClient = new ContentModeratorClient(credentials, `${this.region}.api.cognitive.microsoft.com`);
+            const client: ContentModeratorClient = new ContentModeratorClient(credentials, this.region);
 
             const screenResult: Object = await client.textModeration.screenText(
                 'text/plain',

--- a/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/middleware/contentModeratorMiddleware.ts
@@ -37,7 +37,7 @@ export class ContentModeratorMiddleware implements Middleware {
         if (region === undefined) throw new Error(`Parameter 'region' cannot be undefined.`);
 
         this.subscriptionKey = subscriptionKey;
-        this.region = (region.startsWith('https://') ? region : `https://${ region }`).concat('.api.cognitive.microsoft.com');
+        this.region = region;
     }
 
     /**
@@ -54,7 +54,8 @@ export class ContentModeratorMiddleware implements Middleware {
             const textStream: Readable = this.textToReadable(context.activity.text);
 
             const credentials: CognitiveServicesCredentials = new CognitiveServicesCredentials(this.subscriptionKey);
-            const client: ContentModeratorClient = new ContentModeratorClient(credentials, this.region);
+            const region: string = this.region.startsWith('https://') ? this.region : `https://${ this.region }`;
+            const client: ContentModeratorClient = new ContentModeratorClient(credentials, `${ region }.api.cognitive.microsoft.com`);
 
             const screenResult: Object = await client.textModeration.screenText(
                 'text/plain',


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
