### PR TITLE
[TypeScript][BotBuilder-Solutions] Parity with C# of 'dialogs' folder and implementation on 'routerDialog'

### DIFF
--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
@@ -3,17 +3,20 @@
  * Licensed under the MIT License.
  */
 
+import { TurnContext } from 'botbuilder';
 import { BotTelemetryClient } from 'botbuilder-core';
-import { Dialog, DialogContext, DialogTurnResult, DialogTurnStatus } from 'botbuilder-dialogs';
+import { Dialog, DialogContext, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus } from 'botbuilder-dialogs';
 import { Activity, ActivityTypes } from 'botframework-schema';
 import { ActivityExtensions } from '../extensions';
 import { InterruptableDialog } from './interruptableDialog';
 import { InterruptionAction } from './interruptionAction';
+import { RouterDialogTurnStatus } from './routerDialogTurnStatus';
 
 export abstract class RouterDialog extends InterruptableDialog {
     // Constructor
     public constructor(dialogId: string, telemetryClient: BotTelemetryClient) {
         super(dialogId, telemetryClient);
+        this.telemetryClient = telemetryClient;
     }
 
     protected async onBeginDialog(innerDc: DialogContext, options: object): Promise<DialogTurnResult> {
@@ -44,15 +47,20 @@ export abstract class RouterDialog extends InterruptableDialog {
                     // (i.e. startOnboarding button in intro card)
                     if (activity.value) {
                         await this.onEvent(innerDc);
-                    } else if (activity.text !== undefined && activity.text !== '') {
+                    } else {
                         const result: DialogTurnResult = await innerDc.continueDialog();
+
                         switch (result.status) {
                             case DialogTurnStatus.empty: {
                                 await this.route(innerDc);
                                 break;
                             }
                             case DialogTurnStatus.complete: {
-                                await this.complete(innerDc, result);
+                                if (result.result === RouterDialogTurnStatus.Restart) {
+                                    await this.route(innerDc);
+                                    break;
+                                }
+
                                 // End active dialog
                                 await innerDc.endDialog();
                                 break;
@@ -60,6 +68,13 @@ export abstract class RouterDialog extends InterruptableDialog {
                             default:
                         }
                     }
+
+                    // If the active dialog was ended on this turn (either on single-turn dialog, or on continueDialogAsync)
+                    // run CompleteAsync method.
+                    if (!innerDc.activeDialog) {
+                        await this.complete(innerDc);
+                    }
+
                     break;
                 }
                 case ActivityTypes.Event: {
@@ -80,6 +95,14 @@ export abstract class RouterDialog extends InterruptableDialog {
         }
     }
 
+    protected async onEndDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
+        return super.onEndDialog(context, instance, reason);
+    }
+
+    protected async onRepromptDialog(context: TurnContext, instance: DialogInstance, ): Promise<void> {
+        return super.onRepromptDialog(context, instance);
+    }
+
     /**
      * Called when the inner dialog stack is empty.
      * @param innerDC - The dialog context for the component.
@@ -93,7 +116,7 @@ export abstract class RouterDialog extends InterruptableDialog {
      * @param result - The dialog result when inner dialog completed.
      * @returns A Promise representing the asynchronous operation.
      */
-    protected async complete(innerDc: DialogContext, result: DialogTurnResult): Promise<void> {
+    protected async complete(innerDc: DialogContext, result?: DialogTurnResult): Promise<void> {
         await innerDc.endDialog(result);
 
         return Promise.resolve();

--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
@@ -11,6 +11,7 @@ import { ActivityExtensions } from '../extensions';
 import { InterruptableDialog } from './interruptableDialog';
 import { InterruptionAction } from './interruptionAction';
 import { RouterDialogTurnStatus } from './routerDialogTurnStatus';
+import { RouterDialogTurnResult } from './routerDialogTurnResult';
 
 export abstract class RouterDialog extends InterruptableDialog {
     // Constructor
@@ -56,7 +57,8 @@ export abstract class RouterDialog extends InterruptableDialog {
                                 break;
                             }
                             case DialogTurnStatus.complete: {
-                                if (result.result === RouterDialogTurnStatus.Restart) {
+                                const routerDialogTurnResult: RouterDialogTurnResult = <RouterDialogTurnResult> result.result;
+                                if (routerDialogTurnResult !== undefined && result.status === RouterDialogTurnStatus.Restart) {
                                     await this.route(innerDc);
                                     break;
                                 }
@@ -71,7 +73,7 @@ export abstract class RouterDialog extends InterruptableDialog {
 
                     // If the active dialog was ended on this turn (either on single-turn dialog, or on continueDialogAsync)
                     // run CompleteAsync method.
-                    if (!innerDc.activeDialog) {
+                    if (innerDc.activeDialog === undefined) {
                         await this.complete(innerDc);
                     }
 

--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnResult.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnResult.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { RouterDialogTurnStatus } from './routerDialogTurnStatus';
+
+export class RouterDialogTurnResult {
+
+    constructor(status: RouterDialogTurnStatus) {
+        this.status = status;
+    }
+
+    public status: RouterDialogTurnStatus;
+}

--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnResult.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnResult.ts
@@ -4,6 +4,9 @@
  */
 import { RouterDialogTurnStatus } from './routerDialogTurnStatus';
 
+/**
+ * Define router dialog turn result
+ */
 export class RouterDialogTurnResult {
 
     constructor(status: RouterDialogTurnStatus) {

--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnStatus.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnStatus.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+ /**
+  * Define router dialog turn status.
+  */
  export enum RouterDialogTurnStatus {
      Restart = 0
  }

--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnStatus.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialogTurnStatus.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+ export enum RouterDialogTurnStatus {
+     Restart = 0
+ }


### PR DESCRIPTION
- Add routerDialogTurnResult.ts
- Add routerDialogTurnStatus.ts
- Implementation on routerDialog.ts

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
