### PR TITLE
[TypeScript][BotBuilder-Skills] Update Auth folder

### DIFF
--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/authHelpers.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/authHelpers.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ClaimsIdentity } from 'botframework-connector';
+
+export namespace AuthHelpers {
+
+    export function getAppIdClaimName (claimsIdentity: ClaimsIdentity): string {
+
+        if (claimsIdentity === undefined) {
+            throw new Error('ClaimsIdentity is undefined');
+        }
+
+        // version "1.0" tokens include the "appid" claim and version "2.0" tokens include the "azp" claim
+        let appIdClaimName: string = 'appid';
+        const tokenVersion: string | null = claimsIdentity.getClaimValue(appIdClaimName);
+        if (tokenVersion === '2.0') {
+            appIdClaimName = 'azp';
+        }
+
+        return appIdClaimName;
+    }
+}

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/authHelpers.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/authHelpers.ts
@@ -9,13 +9,10 @@ export namespace AuthHelpers {
 
     export function getAppIdClaimName (claimsIdentity: ClaimsIdentity): string {
 
-        if (claimsIdentity === undefined) {
-            throw new Error('ClaimsIdentity is undefined');
-        }
-
+        if (claimsIdentity === undefined) throw new Error('ClaimsIdentity is undefined');
         // version "1.0" tokens include the "appid" claim and version "2.0" tokens include the "azp" claim
         let appIdClaimName: string = 'appid';
-        const tokenVersion: string | null = claimsIdentity.getClaimValue(appIdClaimName);
+        const tokenVersion: string | null = claimsIdentity.getClaimValue('ver');
         if (tokenVersion === '2.0') {
             appIdClaimName = 'azp';
         }

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticationProvider.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticationProvider.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { ClaimsIdentity } from 'botframework-connector';
+
 export interface IAuthenticationProvider {
-    authenticate(authHeader: string): Promise<boolean>;
+    authenticate(authHeader: string): ClaimsIdentity;
 }

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticator.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticator.ts
@@ -23,26 +23,17 @@ export class Authenticator implements IAuthenticator {
         authenticationProvider: IAuthenticationProvider,
         whitelistAuthenticationProvider: IWhitelistAuthenticationProvider
         ) {
-            if (authenticationProvider === undefined) {
-                throw new Error('error');
-            }
-            if (whitelistAuthenticationProvider === undefined) {
-                throw new Error('error');
-            }
+            if (authenticationProvider === undefined) throw new Error('autheticationProvider is undefined');
+            if (whitelistAuthenticationProvider === undefined) throw new Error('whitelistAuthenticationProvider is undefined');
             this.authenticationProvider = authenticationProvider;
             this.whiteListAuthenticationProvider = whitelistAuthenticationProvider;
         }
 
     public async authenticate(webRequest: WebRequest, webResponse: WebResponse): Promise<ClaimsIdentity> {
-        if (webRequest === undefined) {
-            throw new Error('error');
-        }
-        if (webResponse === undefined) {
-            throw new Error('error');
-        }
+        if (webRequest === undefined) throw new Error('webRequest is undefined');
+        if (webResponse === undefined) throw new Error('webResponse is undefined');
 
         const response: Response = new Response();
-        // tslint:disable-next-line: no-unsafe-any
         const authorizationHeader: string = webRequest.headers('Authorization');
         if (authorizationHeader === '') {
             response.statusCode = 401;
@@ -56,11 +47,10 @@ export class Authenticator implements IAuthenticator {
 
         const appIdClaimName: string = AuthHelpers.getAppIdClaimName(claimsIdentity);
         const appId: string | null = claimsIdentity.getClaimValue(appIdClaimName);
-        if (this.whiteListAuthenticationProvider.appsWhitelist !== undefined &&
+        if (appId !== null && this.whiteListAuthenticationProvider.appsWhitelist !== undefined &&
         this.whiteListAuthenticationProvider.appsWhitelist.size > 0 &&
         !this.whiteListAuthenticationProvider.appsWhitelist.has(appId)) {
             response.statusCode = 401;
-            // tslint:disable-next-line: no-unsafe-any
             await webResponse.send('Skill could not allow access from calling bot.');
         }
 

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticator.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticator.ts
@@ -11,7 +11,7 @@ import { AuthHelpers } from './authHelpers';
 import { IWhitelistAuthenticationProvider } from './whitelistAuthenticationProvider';
 
 export interface IAuthenticator {
-    authenticate(webRequest: WebRequest, webResponse: WebResponse): Promise<ClaimsIdentity | undefined>;
+    authenticate(webRequest: WebRequest, webResponse: WebResponse): Promise<ClaimsIdentity>;
 }
 
 export class Authenticator implements IAuthenticator {
@@ -19,17 +19,14 @@ export class Authenticator implements IAuthenticator {
     private readonly authenticationProvider: IAuthenticationProvider;
     private readonly whiteListAuthenticationProvider: IWhitelistAuthenticationProvider;
 
-    public constructor (
-        authenticationProvider: IAuthenticationProvider,
-        whitelistAuthenticationProvider: IWhitelistAuthenticationProvider
-        ) {
+    public constructor (authenticationProvider: IAuthenticationProvider, whitelistAuthenticationProvider: IWhitelistAuthenticationProvider) {
             if (authenticationProvider === undefined) throw new Error('autheticationProvider is undefined');
             if (whitelistAuthenticationProvider === undefined) throw new Error('whitelistAuthenticationProvider is undefined');
             this.authenticationProvider = authenticationProvider;
             this.whiteListAuthenticationProvider = whitelistAuthenticationProvider;
-        }
+    }
 
-    public async authenticate(httpRequest: WebRequest, httpResponse: WebResponse): Promise<ClaimsIdentity | undefined> {
+    public async authenticate(httpRequest: WebRequest, httpResponse: WebResponse): Promise<ClaimsIdentity> {
         if (httpRequest === undefined) throw new Error('webRequest is undefined');
         if (httpResponse === undefined) throw new Error('webResponse is undefined');
 
@@ -37,15 +34,13 @@ export class Authenticator implements IAuthenticator {
         const authorizationHeader: string = httpRequest.headers('Authorization');
         if (authorizationHeader === undefined || authorizationHeader.trim().length === 0) {
             response.statusCode = 401;
-
-            return undefined;
+            Promise.reject();
         }
 
         const claimsIdentity: ClaimsIdentity = this.authenticationProvider.authenticate(authorizationHeader);
         if (claimsIdentity === undefined) {
             response.statusCode = 401;
-
-            return undefined;
+            Promise.reject();
         }
 
         const appIdClaimName: string = AuthHelpers.getAppIdClaimName(claimsIdentity);

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticator.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/authenticator.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {WebRequest, WebResponse } from 'botbuilder';
+import { ClaimsIdentity } from 'botframework-connector';
+import { Response } from 'microsoft-bot-protocol';
+import { IAuthenticationProvider } from './authenticationProvider';
+import { AuthHelpers } from './authHelpers';
+import { IWhitelistAuthenticationProvider } from './whitelistAuthenticationProvider';
+
+export interface IAuthenticator {
+    authenticate(webRequest: WebRequest, webResponse: WebResponse): Promise<ClaimsIdentity>;
+}
+
+export class Authenticator implements IAuthenticator {
+
+    private readonly authenticationProvider: IAuthenticationProvider;
+    private readonly whiteListAuthenticationProvider: IWhitelistAuthenticationProvider;
+
+    public constructor (
+        authenticationProvider: IAuthenticationProvider,
+        whitelistAuthenticationProvider: IWhitelistAuthenticationProvider
+        ) {
+            if (authenticationProvider === undefined) {
+                throw new Error('error');
+            }
+            if (whitelistAuthenticationProvider === undefined) {
+                throw new Error('error');
+            }
+            this.authenticationProvider = authenticationProvider;
+            this.whiteListAuthenticationProvider = whitelistAuthenticationProvider;
+        }
+
+    public async authenticate(webRequest: WebRequest, webResponse: WebResponse): Promise<ClaimsIdentity> {
+        if (webRequest === undefined) {
+            throw new Error('error');
+        }
+        if (webResponse === undefined) {
+            throw new Error('error');
+        }
+
+        const response: Response = new Response();
+        // tslint:disable-next-line: no-unsafe-any
+        const authorizationHeader: string = webRequest.headers('Authorization');
+        if (authorizationHeader === '') {
+            response.statusCode = 401;
+        }
+
+        const claimsIdentity: ClaimsIdentity = this.authenticationProvider.authenticate(authorizationHeader);
+
+        if (claimsIdentity === undefined) {
+            response.statusCode = 401;
+        }
+
+        const appIdClaimName: string = AuthHelpers.getAppIdClaimName(claimsIdentity);
+        const appId: string | null = claimsIdentity.getClaimValue(appIdClaimName);
+        if (this.whiteListAuthenticationProvider.appsWhitelist !== undefined &&
+        this.whiteListAuthenticationProvider.appsWhitelist.size > 0 &&
+        !this.whiteListAuthenticationProvider.appsWhitelist.has(appId)) {
+            response.statusCode = 401;
+            // tslint:disable-next-line: no-unsafe-any
+            await webResponse.send('Skill could not allow access from calling bot.');
+        }
+
+        return claimsIdentity;
+    }
+}

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/index.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/index.ts
@@ -7,3 +7,6 @@ export * from './authenticationProvider';
 export * from './microsoftAppCredentialsEx';
 export * from './msJWTAuthenticationProvider';
 export * from './serviceClientCredentials';
+export * from './authHelpers';
+export * from './whitelistAuthenticationProvider';
+export * from './authenticator';

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/index.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/index.ts
@@ -4,9 +4,9 @@
  */
 
 export * from './authenticationProvider';
+export * from './authenticator';
+export * from './authHelpers';
 export * from './microsoftAppCredentialsEx';
 export * from './msJWTAuthenticationProvider';
 export * from './serviceClientCredentials';
-export * from './authHelpers';
 export * from './whitelistAuthenticationProvider';
-export * from './authenticator';

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/msJWTAuthenticationProvider.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/msJWTAuthenticationProvider.ts
@@ -14,38 +14,33 @@ declare module 'jsonwebtoken' {
     ): void;
 }
 
-import { HttpOperationResponse, ServiceClient } from '@azure/ms-rest-js';
 import { ClaimsIdentity } from 'botframework-connector';
-import { signingKeyResolver, verify } from 'jsonwebtoken';
 import * as jwks from 'jwks-rsa';
 import { IAuthenticationProvider } from './authenticationProvider';
 
 export class MsJWTAuthenticationProvider implements IAuthenticationProvider {
     // private static openIdConfig: OpenIdConnectConfiguration;
-    private readonly openIdMetadataUrl: string = 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration';
     private readonly microsoftAppId: string;
+    private readonly openIdMetadataUrl: string = 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration';
 
-    public constructor (microsoftAppId: string, openIdMetadataUrl: string = 'undefined') {
-
-        if (microsoftAppId === undefined || microsoftAppId.trim().length === 0) {
-            throw new Error('MicrosoftAppId is undefined');
-        }
+    public constructor (microsoftAppId: string, openIdMetadataUrl: string = '') {
+        if (microsoftAppId === undefined || microsoftAppId.trim().length === 0) throw new Error('MicrosoftAppId is undefined');
         this.microsoftAppId = microsoftAppId;
 
         if (openIdMetadataUrl !== undefined && openIdMetadataUrl.trim().length > 0) {
             this.openIdMetadataUrl = openIdMetadataUrl;
         }
+        /* PENDING: ConfigurationManager and IdentityModel is not present in JS/TS
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                _openIdMetadataUrl,
+                new OpenIdConnectConfigurationRetriever()
+                );
+            openIdConfig = configurationManager.GetConfigurationAsync(CancellationToken.None).GetAwaiter().GetResult();
+        */
     }
 
-    /* PENDING
-        var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-            _openIdMetadataUrl,
-            new OpenIdConnectConfigurationRetriever()
-            );
-        openIdConfig = configurationManager.GetConfigurationAsync(CancellationToken.None).GetAwaiter().GetResult();
-    */
     public authenticate(authHeader: string): ClaimsIdentity {
-        /* PENDING
+        /* PENDING: IdentityModel is not present in JS/TS
             try
             {
                 var validationParameters =

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/msJWTAuthenticationProvider.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/msJWTAuthenticationProvider.ts
@@ -20,7 +20,8 @@ import * as jwks from 'jwks-rsa';
 import { IAuthenticationProvider } from './authenticationProvider';
 
 export class MsJWTAuthenticationProvider implements IAuthenticationProvider {
-    private readonly openIdMetadataUrl: string = 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration';
+    // private static openIdConnectConfiguration: openIdConfig;
+    private openIdMetadataUrl: string = 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration';
     private readonly jwtIssuer: string = 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0';
     private readonly httpClient: ServiceClient;
     private readonly appId: string;
@@ -28,6 +29,13 @@ export class MsJWTAuthenticationProvider implements IAuthenticationProvider {
     public constructor(appId: string) {
         this.httpClient = new ServiceClient();
         this.appId = appId;
+    }
+
+    public msJWTAuthenticationProvider (microsoftAppId: string, openIdMetadataUrl: string = 'undefined'): void {
+        if (microsoftAppId === undefined) {
+            throw new Error('Error');
+            this.openIdMetadataUrl = openIdMetadataUrl;
+        }
     }
 
     public async authenticate(authHeader: string): Promise<boolean> {

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/serviceClientCredentials.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/serviceClientCredentials.ts
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { WebResource } from '@azure/ms-rest-js';
+import { WebRequest } from 'botbuilder';
 
 export interface IServiceClientCredentials {
+    microsoftAppId: string;
+
     getToken(forceRefresh?: boolean): Promise<string>;
-    // eslint-disable-next-line @typescript-eslint/tslint/config, @typescript-eslint/no-explicit-any
-    signRequest(webResource: WebResource | any): Promise<WebResource | any>;
+
+    processHttpRequestAsync(request: WebRequest): Promise<void>;
 }

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/serviceClientCredentials.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/serviceClientCredentials.ts
@@ -9,6 +9,5 @@ export interface IServiceClientCredentials {
     microsoftAppId: string;
 
     getToken(forceRefresh?: boolean): Promise<string>;
-
-    processHttpRequestAsync(request: WebRequest): Promise<void>;
+    processHttpRequest(request: WebRequest): Promise<void>;
 }

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface IServiceClientCredentials {
+    appsWhitelist: Set<string>;
+}

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
@@ -4,15 +4,14 @@
  */
 
 export interface IWhitelistAuthenticationProvider {
-    appsWhitelist: Set<string>;
+    readonly appsWhitelist : Set<string>;
 }
 
 /**
  * Loads the apps whitelist from settings.
  */
-export class WhitelistAuthenticationProvider {
-
-    public readonly appWhiteList: Set<string>;
+export class WhitelistAuthenticationProvider implements IWhitelistAuthenticationProvider {
+    public readonly appsWhitelist: Set<string> = new Set();
 
     public constructor(configuration: any, whitelistProperty: string = 'skillAuthenticationWhitelist') {
         // skillAuthenticationWhitelist is the setting in appsettings.json file
@@ -20,7 +19,6 @@ export class WhitelistAuthenticationProvider {
         // to add a new parent bot simply go to the skillAuthenticationWhitelist and add
         // the parent bot's microsoft app id to the list
         const section: string[] = configuration.whitelistProperty;
-        this.appWhiteList = new Set(section);
+        this.appsWhitelist = new Set(section);
     }
-
 }

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
@@ -3,6 +3,27 @@
  * Licensed under the MIT License.
  */
 
-export interface IServiceClientCredentials {
+export interface IWhitelistAuthenticationProvider {
     appsWhitelist: Set<string>;
+}
+
+/**
+ * Loads the apps whitelist from settings.
+ */
+export class WhitelistAuthenticationProvider {
+
+    public whitelistAuthenticationProvider(
+        configuration: IConfiguration,
+        whitelistProperty: string = 'skillAuthenticationWhitelist'
+        ): void {
+        // skillAuthenticationWhitelist is the setting in appsettings.json file
+        // that conists of the list of parent bot ids that are allowed to access the skill
+        // to add a new parent bot simply go to the skillAuthenticationWhitelist and add
+        // the parent bot's microsoft app id to the list
+        const section: string = configuration.GetSection(whitelistProperty);
+        const appsList: string = section.Get<string[]>();
+
+        if (appsList !== undefined) {
+        }
+    }
 }

--- a/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
+++ b/sdk/typescript/libraries/botbuilder-skills/src/auth/whitelistAuthenticationProvider.ts
@@ -12,18 +12,15 @@ export interface IWhitelistAuthenticationProvider {
  */
 export class WhitelistAuthenticationProvider {
 
-    public whitelistAuthenticationProvider(
-        configuration: IConfiguration,
-        whitelistProperty: string = 'skillAuthenticationWhitelist'
-        ): void {
+    public readonly appWhiteList: Set<string>;
+
+    public constructor(configuration: any, whitelistProperty: string = 'skillAuthenticationWhitelist') {
         // skillAuthenticationWhitelist is the setting in appsettings.json file
         // that conists of the list of parent bot ids that are allowed to access the skill
         // to add a new parent bot simply go to the skillAuthenticationWhitelist and add
         // the parent bot's microsoft app id to the list
-        const section: string = configuration.GetSection(whitelistProperty);
-        const appsList: string = section.Get<string[]>();
-
-        if (appsList !== undefined) {
-        }
+        const section: string[] = configuration.whitelistProperty;
+        this.appWhiteList = new Set(section);
     }
+
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- [X] Add Authenticator
- [X] Add AuthHelpers
- [X] Update IAuthenticationProvider
- [X] Add Iauthenticator
- [x] Update IServiceClientCredentials
- [x] IWhitelistAuthenticationProvider
- [X] MsJWTAuthenticationProvider
- [X] Add WhitelistAuthenticationProvider

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
