### PR TITLE
[Botskills] Display a warning when the tool found an unrecognized scope

### DIFF
--- a/tools/botskills/src/utils/authenticationUtils.ts
+++ b/tools/botskills/src/utils/authenticationUtils.ts
@@ -13,7 +13,8 @@ import {
     IConnectConfiguration,
     IOauthConnection,
     IScopeManifest,
-    ISkillManifest } from '../models';
+    ISkillManifest
+} from '../models';
 import { ChildProcessUtils, isValidAzVersion } from './';
 
 export class AuthenticationUtils {
@@ -82,16 +83,30 @@ export class AuthenticationUtils {
         return this.scopeMap.get(scope) || '';
     }
 
-    private createScopeManifest(scopes: string[]): IScopeManifest[] {
+    private createScopeManifest(scopes: string[], logger: ILogger): IScopeManifest[] {
+        const scopesRecognized: string [] = [];
+        const scopesNotRecognized: string [] = [];
+        scopes.forEach((scope: string) => {
+            if (scope.trim().length > 0) {
+                if (this.scopeMap.has(scope)) {
+                    scopesRecognized.push(scope);
+                } else {
+                    scopesNotRecognized.push(scope);
+                }
+            }
+        });
+        if (scopesNotRecognized.length > 0) {
+            logger.warning(`The following scopes were not recognized: ${scopesNotRecognized.join(',')}`);
+        }
+
         return [{
             resourceAppId: '00000003-0000-0000-c000-000000000000',
-            resourceAccess: scopes.filter((scope: string) => this.scopeMap.has(scope))
-                .map((scope: string) => {
-                    return {
-                        id: this.getScopeId(scope),
-                        type: 'Scope'
-                    };
-                })
+            resourceAccess: scopesRecognized.map((scope: string) => {
+                return {
+                    id: this.getScopeId(scope),
+                    type: 'Scope'
+                };
+            })
         }];
     }
 
@@ -188,7 +203,7 @@ export class AuthenticationUtils {
 
                     // Remove duplicate scopes
                     scopes = [...new Set(scopes)];
-                    const scopeManifest: IScopeManifest[] = this.createScopeManifest(scopes);
+                    const scopeManifest: IScopeManifest[] = this.createScopeManifest(scopes, logger);
 
                     // get the information of the app
                     const azureAppShowCommand: string[] = ['az', 'ad', 'app', 'show'];
@@ -262,12 +277,12 @@ export class AuthenticationUtils {
                 logger.warning(`There was an error while executing the following command:\n\t${currentCommand.join(' ')}\n${err.message}`);
                 logger.warning(`You must configure one of the following connection types MANUALLY in the Azure Portal:
         ${manifest.authenticationConnections.map((authConn: IAuthenticationConnection) => authConn.serviceProviderId)
-                    .join(', ')}`);
+                        .join(', ')}`);
                 logger.warning(`For more information on setting up the authentication configuration manually go to:\n${this.docLink}`);
             } else if (manifest.authenticationConnections && manifest.authenticationConnections.length > 0) {
                 logger.warning(`${err.message} You must configure one of the following connection types MANUALLY in the Azure Portal:
         ${manifest.authenticationConnections.map((authConn: IAuthenticationConnection) => authConn.serviceProviderId)
-                    .join(', ')}`);
+                        .join(', ')}`);
                 logger.warning(`For more information on setting up the authentication configuration manually go to:\n${this.docLink}`);
             } else {
                 logger.warning(err.message);

--- a/tools/botskills/src/utils/authenticationUtils.ts
+++ b/tools/botskills/src/utils/authenticationUtils.ts
@@ -86,6 +86,8 @@ export class AuthenticationUtils {
     private createScopeManifest(scopes: string[], logger: ILogger): IScopeManifest[] {
         const scopesRecognized: string [] = [];
         const scopesNotRecognized: string [] = [];
+        // Check the scopes that are recognized and set to scopesRecognized
+        // If it's not recognized, it will be set to scopesNotRecognized
         scopes.forEach((scope: string) => {
             if (scope.trim().length > 0) {
                 if (this.scopeMap.has(scope)) {
@@ -95,6 +97,7 @@ export class AuthenticationUtils {
                 }
             }
         });
+        // If any of the scopes were not recognized, it will log a warning showing the list of scopes
         if (scopesNotRecognized.length > 0) {
             logger.warning(`The following scopes were not recognized: ${scopesNotRecognized.join(',')}`);
         }


### PR DESCRIPTION
Close 2627

### Purpose
*What is the context of this pull request? Why is it being done?*
If any scope were not recognized during the authentication process, the tool doesn't notify this. We added a warning showing the list of unrecognized scopes.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

- Separate the `scopesRecognized` and `scopesNotRecognized`
- Show a **warning** if any `scopes` were not recognized
- Add comments for this functionality

![image](https://user-images.githubusercontent.com/11904023/68210696-d7ba0780-ffb4-11e9-9c26-5d52cce1039c.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
This Pull Request doesn't contain tests; we will add those tests in another one.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [X] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
