### PR TITLE
[TypeScript][BotBuilder-Solution] Fix date time extensions tests

### DIFF
--- a/sdk/typescript/libraries/botbuilder-solutions/test/dateTimeExtensions.test.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/dateTimeExtensions.test.js
@@ -103,16 +103,16 @@ describe("date time extensions", function() {
             const dateEsEsSpecificDate = new DateTimeTestData(
                 spanishSpainCulture,
                 specificDate,
-                "viernes 04 de abril",
-                "el viernes 04 de abril",
+                "viernes 04 de Abril",
+                "el viernes 04 de Abril",
                 `${specificDate.toLocaleTimeString()}`,
                 `a la ${specificDate.toLocaleTimeString()}`
             );
             const dateEsEsSpecificDatePluralHour = new DateTimeTestData(
                 spanishSpainCulture,
                 specificDatePluralHour,
-                "viernes 04 de abril",
-                "el viernes 04 de abril",
+                "viernes 04 de Abril",
+                "el viernes 04 de Abril",
                 `${specificDatePluralHour.toLocaleTimeString()}`,
                 `a las ${specificDatePluralHour.toLocaleTimeString()}`
             );
@@ -121,16 +121,16 @@ describe("date time extensions", function() {
             const dateEsMxSpecificDate = new DateTimeTestData(
                 spanishMexicoCulture,
                 specificDate,
-                "viernes 04 de abril",
-                "el viernes 04 de abril",
+                "viernes 04 de Abril",
+                "el viernes 04 de Abril",
                 `${specificDate.toLocaleTimeString()}`,
                 `a la ${specificDate.toLocaleTimeString()}`
             );
             const dateEsMxSpecificDatePluralHour = new DateTimeTestData(
                 spanishMexicoCulture,
                 specificDatePluralHour,
-                "viernes 04 de abril",
-                "el viernes 04 de abril",
+                "viernes 04 de Abril",
+                "el viernes 04 de Abril",
                 `${specificDatePluralHour.toLocaleTimeString()}`,
                 `a las ${specificDatePluralHour.toLocaleTimeString()}`
             );


### PR DESCRIPTION

## Purpose
_What is the context of this pull request? Why is it being done?_
Fix the bugs of `Tests` to that everything works as it should.

## Changes
_Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)_
Fixed the errors of `Tests`.

Some tests that were fixed are:
- [ ] should resolve viernes 04 de abril 1:20:42 AM in es-ES
- [ ] should resolve viernes 04 de abril 4:30:42 AM in es-ES
- [ ] should resolve viernes 04 de abril 1:20:42 AM in es-MX
- [ ] should resolve viernes 04 de abril 4:30:42 AM in es-MX

![image](https://user-images.githubusercontent.com/40918752/68312370-b5e28280-0091-11ea-8644-2f36241eec1a.png)

## Tests
_Is this covered by existing tests or new ones? If no, why not?_
Yes, it's covered by the tests.

### Testing Steps
1. Go to `.\sdk\typescript\libraries\botbuilder-solutions`.
2. Open a terminal in that location and execute `npm install`.
3. Run `npm run build`.
4. Then run `npm run test` and check that everything is alright.

## Feature Plan
_Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues._
\-

### Checklist
#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects