### PR TITLE
[TypeScript][Generator] Remove npmrc references

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/src/copier.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/app/src/copier.js
@@ -76,7 +76,6 @@ class Copier {
     templateFiles.set(`_.eslintrc.js`, `.eslintrc.js`);
     templateFiles.set(`_.eslintignore`, `.eslintignore`);
     templateFiles.set(`_.gitignore`, `.gitignore`);
-    templateFiles.set(`_.npmrc`, `.npmrc`);
     templateFiles.set(`_.nycrc`, `.nycrc`);
     templateFiles.set(
       join(`src`, `bots`, `_dialogBot.ts`),

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/src/copier.js
@@ -74,7 +74,6 @@ class Copier {
     templateFiles.set(`_package.json`, `package.json`);
     templateFiles.set(`_.eslintrc.js`, `.eslintrc.js`);
     templateFiles.set(`_.gitignore`, `.gitignore`);
-    templateFiles.set(`_.npmrc`, `.npmrc`);
     templateFiles.set(`_.nycrc`, `.nycrc`);
     templateFiles.set(
       join(`pipeline`, `_sample-skill.yml`),

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.skill.test.suite.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.skill.test.suite.js
@@ -34,7 +34,6 @@ describe(`The generator-botbuilder-assistant skill tests`, function() {
         `package.json`,
         `.eslintrc.js`,
         `.gitignore`,
-        `.npmrc`,
         `.nycrc`,
         manifestTemplatePath,
         dialogBotPath,

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/test/generator-botbuilder-assistant.test.suite.js
@@ -29,7 +29,6 @@ describe(`The generator-botbuilder-assistant tests`, function() {
         `.eslintrc.js`,
         `.eslintignore`,
         `.gitignore`,
-        `.npmrc`,
         `.nycrc`,
         dialogBotPath
     ];


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
Executing the `generator-botbuilder-assistant` of `master` branch presents an issue that .npmrc file is not found.

![image](https://user-images.githubusercontent.com/11904023/69973416-3e720880-1502-11ea-9b4e-3df4d34a7f52.png)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Remove the `.npmrc` references in the creation of samples
- Remove the `.npmrc` references in the generator tests

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
As the npmrc is removed, we removed the related tests

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-
### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
