### PR TITLE
[BotBuilder-Solutions] End the executed dialog when an issue is raised

### DIFF
--- a/docs/_docs/help/known-issues.md
+++ b/docs/_docs/help/known-issues.md
@@ -182,3 +182,36 @@ In the Bot Builder SDK version 4.5.3 and below, there is a bug which causes the 
 For more information, refer to the following resources:
 - [Bot Builder SDK issue](https://github.com/microsoft/botbuilder-dotnet/issues/2474)
 - [Bot Builder SDK pull request](https://github.com/microsoft/botbuilder-dotnet/pull/2580)
+
+## Dialogs are not ending when an error is raised in the conversation
+There is a known issue in the dialogs of the Virtual Assistant and the Skill in which the executed conversation is not ending when an error is raised, this is happening in C# and in TypeScript as well.
+
+To resolve this issue, it's necessary to add a `try/catch` in the `MainDialog` of the bots, to handle any error during the conversation:
+
+[MainDialog.ts](https://github.com/microsoft/botframework-solutions/blob/master/templates/Virtual-Assistant-Template/typescript/samples/sample-assistant/src/dialogs/mainDialog.ts)
+```typescript
+protected async onContinueDialog(dc: DialogContext): Promise<DialogTurnResult> {
+    try {
+        …
+    } catch (error) {
+        …
+        return await dc.endDialog();
+    }
+}
+```
+
+[MainDialog.cs](https://github.com/microsoft/botframework-solutions/blob/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs)
+```C#
+protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext innerDc, CancellationToken cancellationToken = default)
+    try {
+        …
+    } catch (Exception ex) {
+        …
+        return await innerDc.EndDialogAsync().ConfigureAwait(false);
+    }
+}
+```
+
+For more information, check the following issues:
+* [#1589](https://github.com/microsoft/botframework-solutions/issues/1589) - `OnTurnError function inside DefaultAdapter doesn't end the current dialog`
+* [#2766](https://github.com/microsoft/botframework-solutions/issues/2766) - `OnTurnError is not getting called in VA`

--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
@@ -17,16 +17,7 @@ export abstract class RouterDialog extends InterruptableDialog {
     }
 
     protected async onBeginDialog(innerDc: DialogContext, options: object): Promise<DialogTurnResult> {
-        try {
-
-            return this.onContinueDialog(innerDc);
-        } catch (err) {
-            await innerDc.context.sendActivity({
-                type: ActivityTypes.Trace,
-                text: err.message
-            });
-            return await innerDc.endDialog();
-        }
+        return this.onContinueDialog(innerDc);
     }
 
     protected async onContinueDialog(innerDc: DialogContext): Promise<DialogTurnResult> {

--- a/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/dialogs/routerDialog.ts
@@ -17,66 +17,83 @@ export abstract class RouterDialog extends InterruptableDialog {
     }
 
     protected async onBeginDialog(innerDc: DialogContext, options: object): Promise<DialogTurnResult> {
-        return this.onContinueDialog(innerDc);
+        try {
+
+            return this.onContinueDialog(innerDc);
+        } catch (err) {
+            await innerDc.context.sendActivity({
+                type: ActivityTypes.Trace,
+                text: err.message
+            });
+            return await innerDc.endDialog();
+        }
     }
 
     protected async onContinueDialog(innerDc: DialogContext): Promise<DialogTurnResult> {
-        const status: InterruptionAction = await this.onInterruptDialog(innerDc);
+        try {
+            const status: InterruptionAction = await this.onInterruptDialog(innerDc);
 
-        if (status === InterruptionAction.MessageSentToUser) {
-            // Resume the waiting dialog after interruption
-            await innerDc.repromptDialog();
+            if (status === InterruptionAction.MessageSentToUser) {
+                // Resume the waiting dialog after interruption
+                await innerDc.repromptDialog();
 
-            return Dialog.EndOfTurn;
-        } else if (status === InterruptionAction.StartedDialog) {
-            // Stack is already waiting for a response, shelve inner stack
-            return Dialog.EndOfTurn;
-        } else {
-            const activity: Activity = innerDc.context.activity;
+                return Dialog.EndOfTurn;
+            } else if (status === InterruptionAction.StartedDialog) {
+                // Stack is already waiting for a response, shelve inner stack
+                return Dialog.EndOfTurn;
+            } else {
+                const activity: Activity = innerDc.context.activity;
 
-            if (ActivityExtensions.isStartActivity(activity)) {
-                await this.onStart(innerDc);
-            }
+                if (ActivityExtensions.isStartActivity(activity)) {
+                    await this.onStart(innerDc);
+                }
 
-            switch (activity.type) {
-                case ActivityTypes.Message: {
-                    // Note: This check is a workaround for adaptive card buttons that should map to an event
-                    // (i.e. startOnboarding button in intro card)
-                    if (activity.value) {
-                        await this.onEvent(innerDc);
-                    } else if (activity.text !== undefined && activity.text !== '') {
-                        const result: DialogTurnResult = await innerDc.continueDialog();
-                        switch (result.status) {
-                            case DialogTurnStatus.empty: {
-                                await this.route(innerDc);
-                                break;
+                switch (activity.type) {
+                    case ActivityTypes.Message: {
+                        // Note: This check is a workaround for adaptive card buttons that should map to an event
+                        // (i.e. startOnboarding button in intro card)
+                        if (activity.value) {
+                            await this.onEvent(innerDc);
+                        } else if (activity.text !== undefined && activity.text !== '') {
+                            const result: DialogTurnResult = await innerDc.continueDialog();
+                            switch (result.status) {
+                                case DialogTurnStatus.empty: {
+                                    await this.route(innerDc);
+                                    break;
+                                }
+                                case DialogTurnStatus.complete: {
+                                    await this.complete(innerDc, result);
+                                    // End active dialog
+                                    await innerDc.endDialog();
+                                    break;
+                                }
+                                default:
                             }
-                            case DialogTurnStatus.complete: {
-                                await this.complete(innerDc, result);
-                                // End active dialog
-                                await innerDc.endDialog();
-                                break;
-                            }
-                            default:
                         }
+                        break;
                     }
-                    break;
+                    case ActivityTypes.Event: {
+                        await this.onEvent(innerDc);
+                        break;
+                    }
+                    case ActivityTypes.Invoke: {
+                        // Used by Teams for Authentication scenarios.
+                        await innerDc.continueDialog();
+                        break;
+                    }
+                    default: {
+                        await this.onSystemMessage(innerDc);
+                    }
                 }
-                case ActivityTypes.Event: {
-                    await this.onEvent(innerDc);
-                    break;
-                }
-                case ActivityTypes.Invoke: {
-                    // Used by Teams for Authentication scenarios.
-                    await innerDc.continueDialog();
-                    break;
-                }
-                default: {
-                    await this.onSystemMessage(innerDc);
-                }
-            }
 
-            return Dialog.EndOfTurn;
+                return Dialog.EndOfTurn;
+            }
+        } catch (err) {
+            await innerDc.context.sendActivity({
+                type: ActivityTypes.Trace,
+                text: err.message
+            });
+            return await innerDc.endDialog();
         }
     }
 


### PR DESCRIPTION
Fix 2766

### Purpose
*What is the context of this pull request? Why is it being done?*
The conversation is not ended when an issue is raised during the dialog saving the last state executed.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Add `try/catch` validation to end the executed dialog when an issue is raised.

![image](https://user-images.githubusercontent.com/11904023/70543409-1bbaa200-1b49-11ea-8955-a027dbe8bb8c.png)

![image](https://user-images.githubusercontent.com/11904023/70543395-178e8480-1b49-11ea-8237-ec1dc8a9d6bd.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-
### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-
### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
