### PR TITLE
[Botskills] Implement support for --gov

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -16,7 +16,7 @@ import {
     ISkillManifest,
     IUtteranceSource
 } from '../models';
-import { AuthenticationUtils, ChildProcessUtils, getDispatchNames, isValidCultures, wrapPathWithQuotes } from '../utils';
+import { AuthenticationUtils, ChildProcessUtils, getDispatchNames, isCloudGovernment, isValidCultures, wrapPathWithQuotes } from '../utils';
 import { RefreshSkill } from './refreshSkill';
 
 export class ConnectSkill {
@@ -211,12 +211,20 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
         try {
             // tslint:disable-next-line:no-backbone-get-set-outside-model
             const luisApp: string = <string> executionModelByCulture.get('luisApp');
+
             // Update Dispatch file
             const dispatchAddCommandArguments: string[] = ['--type', '--name', '--filePath', '--intentName', '--dataFolder', '--dispatch'];
+
             dispatchAddCommandArguments.forEach((argument: string): void => {
                 const argumentValue: string = <string> executionModelByCulture.get(argument);
                 dispatchAddCommand.push(...[argument, argumentValue]);
             });
+
+            // Append '--gov true' if it is a government cloud
+            if (await isCloudGovernment() === true) {
+                dispatchAddCommand.push('--gov', 'true');
+            }
+
             await this.runCommand(dispatchAddCommand, `Executing dispatch add for the ${culture} ${luisApp} LU file`);
         } catch (err) {
             throw new Error(`There was an error in the dispatch add command:\nCommand: ${dispatchAddCommand.join(' ')}\n${err}`);

--- a/tools/botskills/src/functionality/refreshSkill.ts
+++ b/tools/botskills/src/functionality/refreshSkill.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { ConsoleLogger, ILogger } from '../logger';
 import { ICognitiveModel, IRefreshConfiguration } from '../models';
-import { ChildProcessUtils, getDispatchNames, wrapPathWithQuotes } from '../utils';
+import { ChildProcessUtils, getDispatchNames, isCloudGovernment, wrapPathWithQuotes } from '../utils';
 
 export class RefreshSkill {
     public logger: ILogger;
@@ -44,6 +44,10 @@ export class RefreshSkill {
                 const argumentValue: string = <string> executionModelByCulture.get(argument);
                 dispatchRefreshCommand.push(...[argument, argumentValue]);
             });
+            // Append '--gov true' if it is a government cloud
+            if (await isCloudGovernment() === true) {
+                dispatchRefreshCommand.push('--gov', 'true');
+            }
             await this.runCommand(
                 dispatchRefreshCommand,
                 `Executing dispatch refresh for the ${dispatchName} file`);

--- a/tools/botskills/src/models/cloud.ts
+++ b/tools/botskills/src/models/cloud.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface ICloud {
+    isActive: boolean;
+    name: string;
+}

--- a/tools/botskills/src/models/index.ts
+++ b/tools/botskills/src/models/index.ts
@@ -28,3 +28,4 @@ export {
     IUtterance,
     IUtteranceSource } from './skillManifest';
 export { IRefreshConfiguration } from './refreshConfiguration';
+export { ICloud } from './cloud';

--- a/tools/botskills/src/utils/azUtils.ts
+++ b/tools/botskills/src/utils/azUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import { gte } from 'semver';
+import { ICloud } from '../models/Cloud';
 import { ChildProcessUtils } from './childProcessUtils';
 
 const azPreviewMessage: string = `Command group 'bot' is in preview. It may be changed/removed in a future release.\r\n`;
@@ -35,4 +36,16 @@ export async function isValidAzVersion(): Promise<boolean> {
     }
 
     return false;
+}
+
+/**
+ * @returns Returns TRUE if the AzureUSGovernment is active
+ */
+// tslint:disable-next-line:export-name
+export async function isCloudGovernment(): Promise<boolean> {
+    const azCloudListCommand: string[] = ['az', 'cloud', 'list'];
+    // tslint:disable-next-line: no-unsafe-any
+    const azCloudList: ICloud[] =  JSON.parse(await childProcess.tryExecute(azCloudListCommand));
+
+    return azCloudList.some((cloud: ICloud) => cloud.isActive && cloud.name === 'AzureUSGovernment');
 }

--- a/tools/botskills/src/utils/index.ts
+++ b/tools/botskills/src/utils/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { AuthenticationUtils } from './authenticationUtils';
-export { isAzPreviewMessage, isValidAzVersion } from './azUtils';
+export { isAzPreviewMessage, isCloudGovernment, isValidAzVersion } from './azUtils';
 export { ChildProcessUtils } from './childProcessUtils';
 export { getDispatchNames } from './dispatchUtils';
 export { sanitizePath, wrapPathWithQuotes } from './sanitizationUtils';


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Implements support for `--gov` in Botskills when running `connectSkill` and `refreshSkill`

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
A new function was added in **AzUtil** along a new model for the response of `az cloud list`

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
