### PR TITLE
[TypeScript] Add tests for LUIS recognizer extension method

### DIFF
--- a/sdk/typescript/libraries/botbuilder-solutions/src/extensions/luisRecognizerEx.ts
+++ b/sdk/typescript/libraries/botbuilder-solutions/src/extensions/luisRecognizerEx.ts
@@ -21,7 +21,7 @@ export namespace LuisRecognizerEx {
         if(luisProperty !== undefined && result !== undefined) {
             let sentimentInfo: any = JSON.parse(<string>result);
             sentimentLabel = getSentimentType(sentimentInfo.label);
-            maxScore = sentimentInfo.score !== undefined ? sentimentInfo.score.value : 0.0;
+            maxScore = sentimentInfo.score !== undefined ? sentimentInfo.score : 0.0;
         }
 
         return ([sentimentLabel, maxScore]);

--- a/sdk/typescript/libraries/botbuilder-solutions/test/helpers/skillLuis.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/helpers/skillLuis.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+class SkillLuis {
+    constructor(properties){
+        this.properties = properties;
+    }
+}
+
+exports.SkillLuis = SkillLuis

--- a/sdk/typescript/libraries/botbuilder-solutions/test/listEx.test.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/listEx.test.js
@@ -17,7 +17,7 @@ describe("list extensions", function() {
 
     describe("defaults", function() {
         it("verify the speech string of multiple strings", function(){
-            i18next.language = 'en-us';
+            i18next.changeLanguage('en-us');
             const andOperator = i18next.t("common:and"); 
             // Default is ToString and final separator is "and"
             const testList = ["One", "Two", "Three"];
@@ -28,7 +28,7 @@ describe("list extensions", function() {
 
     describe("to speech string", function() {
         it("verify the speech string of multiple complex type objects", function(){
-            i18next.language = 'en-us';
+            i18next.changeLanguage('en-us');
             const testList = [];
 
             strictEqual("", ListEx.toSpeechString(testList, this.orOperator, (li) => { return li.number }));

--- a/sdk/typescript/libraries/botbuilder-solutions/test/luisRecognizeEx.test.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/luisRecognizeEx.test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const { strictEqual } = require("assert");
+const { join } = require("path");
+const { SkillLuis } = require(join(__dirname, "helpers", "skillLuis"));
+const { LuisRecognizerEx } = require(join("..", "lib", "extensions", "luisRecognizerEx"));
+const { SentimentType } = require(join("..", "lib", "models", "sentimentType"));
+
+describe("list extensions", function() {
+    before(async function() {
+    });
+
+    describe("luis recognizer", function() {
+        describe("get sentiment info with sentiment enabled", function() {
+            it("should return a sentiment type and its score", function(){
+                const skillLuis = new SkillLuis({ string: "sentiment", object: "{\"label\": \"positive\", \"score\": 0.91}" });
+                const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis);
+
+                strictEqual(SentimentType.Positive, type);
+                strictEqual('0.91', score);
+            });
+        });
+
+        describe("get sentiment info with sentiment not enabled", function() {
+            it("should return a neutral sentiment and no score", function(){
+                const skillLuis = new SkillLuis();
+                const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis);
+
+                strictEqual(SentimentType.None, type);
+                strictEqual('0.0', score);
+            });
+        });
+    });
+});

--- a/sdk/typescript/libraries/botbuilder-solutions/test/luisRecognizeEx.test.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/luisRecognizeEx.test.js
@@ -8,30 +8,38 @@ const { join } = require("path");
 const { SkillLuis } = require(join(__dirname, "helpers", "skillLuis"));
 const { LuisRecognizerEx } = require(join("..", "lib", "extensions", "luisRecognizerEx"));
 const { SentimentType } = require(join("..", "lib", "models", "sentimentType"));
+const sentiment = "sentiment";
 
-describe("list extensions", function() {
-    before(async function() {
+describe("luis recognize extensions", function() {
+    describe("get sentiment info with sentiment enabled", function() {
+        it("should return a sentiment type and its score", function(){
+            const myMap = new Map();
+            myMap.set(sentiment, "{\"label\": \"positive\", \"score\": 0.91}");
+            
+            const skillLuis = new SkillLuis(myMap);
+
+            const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis,
+                (skillLuis) => {
+                  return skillLuis.properties;  
+                } 
+            );
+            strictEqual(SentimentType.Positive, type);
+            strictEqual(0.91, score);
+        });
     });
 
-    describe("luis recognizer", function() {
-        describe("get sentiment info with sentiment enabled", function() {
-            it("should return a sentiment type and its score", function(){
-                const skillLuis = new SkillLuis({ string: "sentiment", object: "{\"label\": \"positive\", \"score\": 0.91}" });
-                const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis);
+    describe("get sentiment info with sentiment not enabled", function() {
+        it("should return a neutral sentiment and no score", function(){
+            const myMap = new Map();
+            const skillLuis = new SkillLuis(myMap);
 
-                strictEqual(SentimentType.Positive, type);
-                strictEqual('0.91', score);
-            });
-        });
-
-        describe("get sentiment info with sentiment not enabled", function() {
-            it("should return a neutral sentiment and no score", function(){
-                const skillLuis = new SkillLuis();
-                const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis);
-
-                strictEqual(SentimentType.None, type);
-                strictEqual('0.0', score);
-            });
+            const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis,
+                (skillLuis) => {
+                  return skillLuis.properties;  
+                } 
+            );
+            strictEqual(SentimentType.None, type);
+            strictEqual(0.0, score);
         });
     });
 });

--- a/sdk/typescript/libraries/botbuilder-solutions/test/luisRecognizeEx.test.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/luisRecognizeEx.test.js
@@ -13,10 +13,10 @@ const sentiment = "sentiment";
 describe("luis recognize extensions", function() {
     describe("get sentiment info with sentiment enabled", function() {
         it("should return a sentiment type and its score", function(){
-            const myMap = new Map();
-            myMap.set(sentiment, "{\"label\": \"positive\", \"score\": 0.91}");
+            const sentiments = new Map();
+            sentiments.set(sentiment, "{\"label\": \"positive\", \"score\": 0.91}");
             
-            const skillLuis = new SkillLuis(myMap);
+            const skillLuis = new SkillLuis(sentiments);
 
             const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis,
                 (skillLuis) => {
@@ -30,8 +30,8 @@ describe("luis recognize extensions", function() {
 
     describe("get sentiment info with sentiment not enabled", function() {
         it("should return a neutral sentiment and no score", function(){
-            const myMap = new Map();
-            const skillLuis = new SkillLuis(myMap);
+            const sentiments = new Map();
+            const skillLuis = new SkillLuis(sentiments);
 
             const [type, score] = LuisRecognizerEx.getSentimentInfo(skillLuis,
                 (skillLuis) => {


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
