### PR TITLE
[TypeScript] Add tests for Template Engine

### DIFF
--- a/sdk/typescript/libraries/botbuilder-solutions/test/languageGeneration.test.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/languageGeneration.test.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const { strictEqual } = require("assert");
+const { join } = require("path");
+const i18next = require("i18next").default;
+const { SomeComplexType } = require(join(__dirname, "helpers", "someComplexType"));
+//const { ListExtensions } = require(join("..", "lib", "extensions", "listEx"));
+const { LocaleTemplateEngineManager } = require(join("..", "lib", "responses", "localeTemplateEngineManager"));
+
+const localeTemplateEngineManager;
+
+describe("language generation", function() {
+    before(async function() {
+        const localeLgFiles = [];
+        localeLgFiles.push({
+            key: "en-us",
+            value: [join(".", "Response", "TestResponses.lg")]
+        });
+        localeLgFiles.push({
+            key: "es-es",
+            value: [join(".", "Response", "TestResponses.es.lg")]
+        });
+
+        i18next.use(i18nextNodeFsBackend)
+        .init({
+            fallbackLng: "en",
+            preload: [ "de", "en", "es", "fr", "it", "zh" ],
+            backend: {
+                loadPath: join(__dirname, "locales", "{{lng}}.json")
+            }
+        })
+        .then(async () => {
+            await Locales.addResourcesFromPath(i18next, "common");
+        });
+
+        localeTemplateEngineManager = new LocaleTemplateEngineManager(localeLgFiles, "en-us");
+    });
+    
+    describe("get response with language generation english", function() {
+        i18next.changeLanguage("en");
+
+        // Generate English response using LG with data
+        let data = { name: "Darren" };
+        let response = localeTemplateEngineManager.generateActivityForLocale("HaveNameMessage", data);
+
+        // Retrieve possible responses directly from the correct template to validate logic
+        var possibleResponses = localeTemplateEngineManager.templateEnginesPerLocale["en-us"].expandTemplate("HaveNameMessage", data);
+
+        strictEqual(possibleResponses.includes(response.text));
+    });
+});

--- a/sdk/typescript/libraries/botbuilder-solutions/test/languageGeneration.test.js
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/languageGeneration.test.js
@@ -11,17 +11,20 @@ const { LocaleTemplateEngineManager } = require(join("..", "lib", "responses", "
 let localeTemplateEngineManager;
 
 describe("language generation", function() {
-    before(async function() {
+    after(async function() {
+        i18next.changeLanguage('en-us');
+    });
 
+    before(async function() {
         const localeLgFiles = new Map();
         localeLgFiles.set("en-us", [join(__dirname, "responses", "testResponses.lg")]);
         localeLgFiles.set("es-es", [join(__dirname, "responses", "testResponses.es.lg")]);
 
-        localeTemplateEngineManager = new LocaleTemplateEngineManager(localeLgFiles, "en");
+        localeTemplateEngineManager = new LocaleTemplateEngineManager(localeLgFiles, "en-us");
     });
     
     describe("get response with language generation english", function() {
-        it("should return a list that contains the response text", function() {
+        it("should return the correct response included in the possible responses of the locale", function() {
             i18next.changeLanguage("en-us");
 
             // Generate English response using LG with data
@@ -36,7 +39,7 @@ describe("language generation", function() {
     });
 
     describe("get response with language generation spanish", function() {
-        it("should return a list that contains the response text", function() {
+        it("should return the correct response included in the possible responses of the locale", function() {
             i18next.changeLanguage("es-es");
 
             // Generate Spanish response using LG with data
@@ -66,9 +69,5 @@ describe("language generation", function() {
 
             strictEqual(possibleResponses.includes(response.text));
         });
-    });
-
-    after(async function() {
-        i18next.changeLanguage('en-us');
     });
 });

--- a/sdk/typescript/libraries/botbuilder-solutions/test/responses/testResponses.es.lg
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/responses/testResponses.es.lg
@@ -1,0 +1,4 @@
+﻿# HaveNameMessage
+- Hola @{Name}!
+- Hola @{Name}!
+- Mucho gusto @{Name}

--- a/sdk/typescript/libraries/botbuilder-solutions/test/responses/testResponses.lg
+++ b/sdk/typescript/libraries/botbuilder-solutions/test/responses/testResponses.lg
@@ -1,0 +1,4 @@
+﻿# HaveNameMessage
+- Hi @{Name}!
+- Hi There @{Name}!
+- Pleased to meet you @{Name}


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
