### PR TITLE
[TypeScript][Skill] Add onTurnError handler

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/adapters/defaultAdapter.ts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/adapters/defaultAdapter.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+    ActivityTypes,
     AutoSaveStateMiddleware,
     BotFrameworkAdapter,
     BotFrameworkAdapterSettings,
@@ -13,6 +14,7 @@ import {
     TelemetryLoggerMiddleware,
     TranscriptLoggerMiddleware,
     TranscriptStore,
+    TurnContext,
     UserState} from 'botbuilder';
 import { AzureBlobTranscriptStore } from 'botbuilder-azure';
 import {
@@ -29,6 +31,19 @@ export class DefaultAdapter extends BotFrameworkAdapter {
         telemetryClient: BotTelemetryClient
     ) {
         super(adapterSettings);
+
+        this.onTurnError = async (context: TurnContext, error: Error): Promise<void> => {
+            await context.sendActivity({
+                type: ActivityTypes.Trace,
+                text: error.message
+            });
+            await context.sendActivity({
+                type: ActivityTypes.Trace,
+                text: error.stack
+            });
+            await context.sendActivity(i18next.t('main.error'));
+            telemetryClient.trackException({ exception: error });
+        };
 
         if (settings.blobStorage === undefined) {
             throw new Error('There is no blobStorage value in appsettings file');

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/adapters/defaultAdapter.ts
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/generators/skill/templates/sample-skill/src/adapters/defaultAdapter.ts
@@ -35,13 +35,12 @@ export class DefaultAdapter extends BotFrameworkAdapter {
         this.onTurnError = async (context: TurnContext, error: Error): Promise<void> => {
             await context.sendActivity({
                 type: ActivityTypes.Trace,
-                text: error.message
+                text: error.message || JSON.stringify(error)
             });
             await context.sendActivity({
                 type: ActivityTypes.Trace,
                 text: error.stack
             });
-            await context.sendActivity(i18next.t('main.error'));
             telemetryClient.trackException({ exception: error });
         };
 

--- a/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/adapters/defaultAdapter.ts
+++ b/templates/Virtual-Assistant-Template/typescript/samples/sample-skill/src/adapters/defaultAdapter.ts
@@ -32,10 +32,6 @@ export class DefaultAdapter extends BotFrameworkAdapter {
     ) {
         super(adapterSettings);
 
-        if (settings.blobStorage === undefined) {
-            throw new Error('There is no blobStorage value in appsettings file');
-        }
-
         this.onTurnError = async (context: TurnContext, error: Error): Promise<void> => {
             await context.sendActivity({
                 type: ActivityTypes.Trace,
@@ -47,6 +43,10 @@ export class DefaultAdapter extends BotFrameworkAdapter {
             });
             telemetryClient.trackException({ exception: error });
         };
+
+        if (settings.blobStorage === undefined) {
+            throw new Error('There is no blobStorage value in appsettings file');
+        }
 
         const transcriptStore: TranscriptStore = new AzureBlobTranscriptStore({
             containerName: settings.blobStorage.container,


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
Currently, the `defaultAdapter`  of the Skill for TypeScript does not catch `uncaught exceptions`.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Add a `onTurnError` handler on the `defaultAdapter` as shown below:

![image](https://user-images.githubusercontent.com/39467613/72746803-ccc54b00-3b91-11ea-90e6-858ba4799d52.png)

**Note:** This, however, would still require to disable the `ShowTypingMiddleware` for it to catch the exceptions.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
