### PR TITLE
[TypeScript] Implement endpointName parameter for Botskills

### DIFF
--- a/tools/botskills/src/botskills-connect.ts
+++ b/tools/botskills/src/botskills-connect.ts
@@ -32,6 +32,7 @@ program
     .description('Connect a skill to your assistant bot. Only one of both path or URL to Skill is needed.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
+    .option('-n, --endpointName <name>', 'Name of the endpoint to connect to your assistant (case sensitive)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be refreshed (by default they are refreshed)')
@@ -57,6 +58,7 @@ if (process.argv.length < 3) {
 let botName: string = '';
 let localManifest: string;
 let remoteManifest: string;
+let endpointName: string;
 let noRefresh: boolean = false;
 let languages: string[];
 let luisFolder: string;
@@ -105,6 +107,7 @@ if (args.localManifest && extname(args.localManifest) !== '.json') {
 
 localManifest = args.localManifest;
 remoteManifest = args.remoteManifest;
+endpointName = args.endpointName;
 
 // outFolder validation -- the var is needed for reassuring 'configuration.outFolder' is not undefined
 outFolder = args.outFolder ? sanitizePath(args.outFolder) : resolve('./');
@@ -160,6 +163,7 @@ const configuration: IConnectConfiguration = {
     botName: botName,
     localManifest: localManifest,
     remoteManifest: remoteManifest,
+    endpointName: endpointName,
     noRefresh: noRefresh,
     languages: languages,
     luisFolder: luisFolder,

--- a/tools/botskills/src/botskills-connect.ts
+++ b/tools/botskills/src/botskills-connect.ts
@@ -32,7 +32,7 @@ program
     .description('Connect a skill to your assistant bot. Only one of both path or URL to Skill is needed.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
-    .option('-e, --endpointName <name>', '[OPTIONAL] Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
+    .option('-e, --endpointName <name>', '[OPTIONAL] Name of the endpoint to connect to your assistant (case sensitive)(by default the tool will use the first endpoint of the manifest)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be refreshed (by default they are refreshed)')

--- a/tools/botskills/src/botskills-connect.ts
+++ b/tools/botskills/src/botskills-connect.ts
@@ -32,7 +32,7 @@ program
     .description('Connect a skill to your assistant bot. Only one of both path or URL to Skill is needed.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
-    .option('-n, --endpointName <name>', 'Name of the endpoint to connect to your assistant (case sensitive)')
+    .option('-e, --endpointName <name>', '[OPTIONAL]Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be refreshed (by default they are refreshed)')

--- a/tools/botskills/src/botskills-connect.ts
+++ b/tools/botskills/src/botskills-connect.ts
@@ -32,7 +32,7 @@ program
     .description('Connect a skill to your assistant bot. Only one of both path or URL to Skill is needed.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
-    .option('-e, --endpointName <name>', '[OPTIONAL]Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
+    .option('-e, --endpointName <name>', '[OPTIONAL] Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be refreshed (by default they are refreshed)')

--- a/tools/botskills/src/botskills-update.ts
+++ b/tools/botskills/src/botskills-update.ts
@@ -32,6 +32,7 @@ program
     .description('Update a specific skill from your assistant bot.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
+    .option('-n, --endpointName <name>', 'Name of the endpoint to connect to your assistant (case sensitive)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be trained (by default they are trained)')
@@ -58,6 +59,7 @@ const skillId: string = '';
 let botName: string = '';
 let localManifest: string;
 let remoteManifest: string;
+let endpointName: string;
 let noRefresh: boolean = false;
 let languages: string[];
 let luisFolder: string;
@@ -106,6 +108,7 @@ if (args.localManifest && extname(args.localManifest) !== '.json') {
 
 localManifest = args.localManifest;
 remoteManifest = args.remoteManifest;
+endpointName = args.endpointName;
 
 // outFolder validation -- the var is needed for reassuring 'configuration.outFolder' is not undefined
 outFolder = args.outFolder ? sanitizePath(args.outFolder) : resolve('./');
@@ -164,6 +167,7 @@ const configuration: IUpdateConfiguration = {
     botName: botName,
     localManifest: localManifest,
     remoteManifest: remoteManifest,
+    endpointName: endpointName,
     noRefresh: noRefresh,
     languages: languages,
     luisFolder: luisFolder,

--- a/tools/botskills/src/botskills-update.ts
+++ b/tools/botskills/src/botskills-update.ts
@@ -32,7 +32,7 @@ program
     .description('Update a specific skill from your assistant bot.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
-    .option('-e, --endpointName <name>', '[OPTIONAL] Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
+    .option('-e, --endpointName <name>', '[OPTIONAL] Name of the endpoint to connect to your assistant (case sensitive)(by default the tool will use the first endpoint of the manifest)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be trained (by default they are trained)')

--- a/tools/botskills/src/botskills-update.ts
+++ b/tools/botskills/src/botskills-update.ts
@@ -32,7 +32,7 @@ program
     .description('Update a specific skill from your assistant bot.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
-    .option('-e, --endpointName <name>', '[OPTIONAL]Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
+    .option('-e, --endpointName <name>', '[OPTIONAL] Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be trained (by default they are trained)')

--- a/tools/botskills/src/botskills-update.ts
+++ b/tools/botskills/src/botskills-update.ts
@@ -32,7 +32,7 @@ program
     .description('Update a specific skill from your assistant bot.')
     .option('-l, --localManifest <path>', 'Path to local Skill Manifest file')
     .option('-r, --remoteManifest <url>', 'URL to remote Skill Manifest')
-    .option('-n, --endpointName <name>', 'Name of the endpoint to connect to your assistant (case sensitive)')
+    .option('-e, --endpointName <name>', '[OPTIONAL]Name of the endpoint to connect to your assistant (case sensitive)(defaults to using the first endpoint)')
     .option('--cs', 'Determine your assistant project structure to be a CSharp-like structure')
     .option('--ts', 'Determine your assistant project structure to be a TypeScript-like structure')
     .option('--noRefresh', '[OPTIONAL] Determine whether the model of your skills connected are not going to be trained (by default they are trained)')

--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -17,7 +17,8 @@ import {
     ISkillManifestV2,
     IAppSetting,
     ISkill,
-    IModel
+    IModel,
+    IEndpoint
 } from '../models';
 import { ChildProcessUtils, getDispatchNames, isValidCultures, wrapPathWithQuotes, isInstanceOfISkillManifestV1, isInstanceOfISkillManifestV2 } from '../utils';
 import { RefreshSkill } from './refreshSkill';
@@ -316,10 +317,13 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
 
         if (isInstanceOfISkillManifestV2(skill as ISkillManifestV2)) {
             const skillManifestV2: ISkillManifestV2 = skill as ISkillManifestV2;
+            const endpoint: IEndpoint = skillManifestV2.endpoints.find((endpoint) => endpoint.name === this.configuration.endpointName) 
+            || skillManifestV2.endpoints[0];
+            
             assistantSkills.push({
                 Id: skillManifestV2.$id,
-                AppId: skillManifestV2.endpoints[0].msAppId,
-                SkillEndpoint: skillManifestV2.endpoints[0].endpointUrl,
+                AppId: endpoint.msAppId,
+                SkillEndpoint: endpoint.endpointUrl,
             })
             assistantSkillsFile.BotFrameworkSkills = assistantSkills;
         }

--- a/tools/botskills/src/models/connectConfiguration.ts
+++ b/tools/botskills/src/models/connectConfiguration.ts
@@ -9,6 +9,7 @@ export interface IConnectConfiguration {
     botName: string;
     localManifest: string;
     remoteManifest: string;
+    endpointName: string;
     noRefresh: boolean;
     languages: string[];
     luisFolder: string;

--- a/tools/botskills/src/models/updateConfiguration.ts
+++ b/tools/botskills/src/models/updateConfiguration.ts
@@ -10,6 +10,7 @@ export interface IUpdateConfiguration {
     botName: string;
     localManifest: string;
     remoteManifest: string;
+    endpointName: string;
     noRefresh: boolean;
     languages: string[];
     luisFolder: string;


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
