### PR TITLE
[Botskills] Update manifests validations

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -152,7 +152,8 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
         let validVersion: manifestVersion = manifestVersion.none;
         switch (skillManifestVersion) {
             case manifestVersion.V1: {
-                if (!manifestV1Validation(skillManifest as ISkillManifestV1, this.logger).isError)
+                manifestV1Validation(skillManifest as ISkillManifestV1, this.logger);
+                if (!this.logger.isError)
                 {
                     validVersion = manifestVersion.V1;
                     break;
@@ -160,7 +161,8 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
                 throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
             }
             case manifestVersion.V2: {
-                if (!manifestV2Validation(skillManifest as ISkillManifestV2, this.logger, this.configuration.endpointName).isError)
+                manifestV2Validation(skillManifest as ISkillManifestV2, this.logger, this.configuration.endpointName);
+                if (!this.logger.isError)
                 {
                     validVersion = manifestVersion.V2;
                     break;
@@ -353,10 +355,6 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
             // Manifest schema validation
             this.skillManifestValidated = this.validateManifestSchema(skillManifest);
             // End of manifest schema validation
-
-            if (this.logger.isError) {
-                return false;
-            }
 
             switch (this.skillManifestValidated) {
                 case manifestVersion.V1: {

--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -20,12 +20,13 @@ import {
     IModel,
     IEndpoint
 } from '../models';
-import { ChildProcessUtils, getDispatchNames, isValidCultures, wrapPathWithQuotes, isInstanceOfISkillManifestV1, isInstanceOfISkillManifestV2 } from '../utils';
+import { ChildProcessUtils, getDispatchNames, isValidCultures, wrapPathWithQuotes, manifestV1Validation, manifestV2Validation } from '../utils';
 import { RefreshSkill } from './refreshSkill';
 
 enum manifestVersion {
     V1 = 'V1',
-    V2 = 'V2'
+    V2 = 'V2',
+    none = 'none'
 }
 
 export class ConnectSkill {
@@ -34,6 +35,7 @@ export class ConnectSkill {
     private readonly logger: ILogger;
     private manifestVersion: manifestVersion | undefined;
     private skillManifest: ISkillManifestV2 | undefined;
+    private skillManifestValidated: manifestVersion = manifestVersion.none;
 
     public constructor(configuration: IConnectConfiguration, logger?: ILogger) {
         this.configuration = configuration;
@@ -140,15 +142,38 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
 
     private validateManifestSchema(skillManifest: ISkillManifestV1 | ISkillManifestV2): manifestVersion {
 
-        if (isInstanceOfISkillManifestV1(skillManifest as ISkillManifestV1)) {
-            return manifestVersion.V1;
+        const skillManifestV1Validation = skillManifest as ISkillManifestV1;
+        const skillManifestV2Validation = skillManifest as ISkillManifestV2;
+
+        const skillManifestVersion: string | undefined = skillManifestV1Validation.id ? 
+            manifestVersion.V1 : skillManifestV2Validation.$id ?
+                manifestVersion.V2 : undefined;
+        
+        let validVersion: manifestVersion = manifestVersion.none;
+        switch (skillManifestVersion) {
+            case manifestVersion.V1: {
+                if (!manifestV1Validation(skillManifest as ISkillManifestV1, this.logger).isError)
+                {
+                    validVersion = manifestVersion.V1;
+                    break;
+                }
+                throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
+            }
+            case manifestVersion.V2: {
+                if (!manifestV2Validation(skillManifest as ISkillManifestV2, this.logger, this.configuration.endpointName).isError)
+                {
+                    validVersion = manifestVersion.V2;
+                    break;
+                }
+                throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
+            }
+            case undefined: {
+                throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
+            }
         }
-        else if (isInstanceOfISkillManifestV2(skillManifest as ISkillManifestV2)) {
-            return manifestVersion.V2;
-        }
-        else {
-            throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
-        }
+
+        return validVersion;
+        
     }
 
     private async runCommand(command: string[], description: string): Promise<string> {
@@ -326,10 +351,14 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
             // Take skillManifest
             const skillManifest: ISkillManifestV1 | ISkillManifestV2 = await this.getManifest();
             // Manifest schema validation
-            const validVersion: manifestVersion = this.validateManifestSchema(skillManifest);
+            this.skillManifestValidated = this.validateManifestSchema(skillManifest);
             // End of manifest schema validation
 
-            switch (validVersion) {
+            if (this.logger.isError) {
+                return false;
+            }
+
+            switch (this.skillManifestValidated) {
                 case manifestVersion.V1: {
                     this.manifestVersion = manifestVersion.V1;
                     this.connectSkillManifestV1(cognitiveModelsFile, skillManifest as ISkillManifestV1);
@@ -342,10 +371,6 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
                 }
             }
 
-            if (this.logger.isError) {
-                return false;
-            }
-
             return true;
            
         } catch (err) {
@@ -355,18 +380,19 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
     }
 
     private AddSkill(assistantSkillsFile: IAppSetting, assistantSkills: ISkill[], skill: ISkillManifestV1 | ISkillManifestV2): void {
-        if (isInstanceOfISkillManifestV1(skill as ISkillManifestV1)) {
+
+        if (this.skillManifestValidated == manifestVersion.V1) {
             const skillManifestV1: ISkillManifestV1 = skill as ISkillManifestV1;
             assistantSkills.push({
                 Id: skillManifestV1.id,
                 AppId: skillManifestV1.msaAppId,
                 SkillEndpoint: skillManifestV1.endpoint,
                 Name: skillManifestV1.name
-            })
+            });
             assistantSkillsFile.BotFrameworkSkills = assistantSkills;
         }
 
-        if (isInstanceOfISkillManifestV2(skill as ISkillManifestV2)) {
+        if (this.skillManifestValidated == manifestVersion.V2) {
             const skillManifestV2: ISkillManifestV2 = skill as ISkillManifestV2;
             const endpoint: IEndpoint = skillManifestV2.endpoints.find((endpoint: IEndpoint): boolean => endpoint.name === this.configuration.endpointName) 
             || skillManifestV2.endpoints[0];
@@ -376,7 +402,7 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
                 AppId: endpoint.msAppId,
                 SkillEndpoint: endpoint.endpointUrl,
                 Name: skillManifestV2.name,
-            })
+            });
             assistantSkillsFile.BotFrameworkSkills = assistantSkills;
         }
         

--- a/tools/botskills/src/functionality/updateSkill.ts
+++ b/tools/botskills/src/functionality/updateSkill.ts
@@ -10,11 +10,12 @@ import { ConsoleLogger, ILogger } from '../logger';
 import { IConnectConfiguration, IDisconnectConfiguration, ISkillManifestV2, ISkillManifestV1, IUpdateConfiguration, ISkill, IAppSetting } from '../models';
 import { ConnectSkill } from './connectSkill';
 import { DisconnectSkill } from './disconnectSkill';
-import { isInstanceOfISkillManifestV1, isInstanceOfISkillManifestV2 } from '../utils';
+import { manifestV1Validation, manifestV2Validation } from '../utils';
 
 enum manifestVersion {
     V1 = 'V1',
-    V2 = 'V2'
+    V2 = 'V2',
+    none = 'none'
 }
 
 export class UpdateSkill {
@@ -50,15 +51,38 @@ Please make sure to provide a valid path to your Skill manifest using the '--loc
 
     private validateManifestSchema(skillManifest: ISkillManifestV1 | ISkillManifestV2): manifestVersion {
 
-        if (isInstanceOfISkillManifestV1(skillManifest as ISkillManifestV1)) {
-            return manifestVersion.V1;
+        const skillManifestV1Validation = skillManifest as ISkillManifestV1;
+        const skillManifestV2Validation = skillManifest as ISkillManifestV2;
+
+        const skillManifestVersion: string | undefined = skillManifestV1Validation.id ? 
+            manifestVersion.V1 : skillManifestV2Validation.$id ?
+                manifestVersion.V2 : undefined;
+        
+        let validVersion: manifestVersion = manifestVersion.none;
+        switch (skillManifestVersion) {
+            case manifestVersion.V1: {
+                if (!manifestV1Validation(skillManifest as ISkillManifestV1, this.logger).isError)
+                {
+                    validVersion = manifestVersion.V1;
+                    break;
+                }
+                throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
+            }
+            case manifestVersion.V2: {
+                if (!manifestV2Validation(skillManifest as ISkillManifestV2, this.logger, this.configuration.endpointName).isError)
+                {
+                    validVersion = manifestVersion.V2;
+                    break;
+                }
+                throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
+            }
+            case undefined: {
+                throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
+            }
         }
-        else if (isInstanceOfISkillManifestV2(skillManifest as ISkillManifestV2)) {
-            return manifestVersion.V2;
-        }
-        else {
-            throw new Error('The Skill Manifest is not compatible with any version supported.');
-        }
+
+        return validVersion;
+        
     }
 
     private async getManifest(): Promise<ISkillManifestV1 | ISkillManifestV2> {

--- a/tools/botskills/src/functionality/updateSkill.ts
+++ b/tools/botskills/src/functionality/updateSkill.ts
@@ -61,7 +61,8 @@ Please make sure to provide a valid path to your Skill manifest using the '--loc
         let validVersion: manifestVersion = manifestVersion.none;
         switch (skillManifestVersion) {
             case manifestVersion.V1: {
-                if (!manifestV1Validation(skillManifest as ISkillManifestV1, this.logger).isError)
+                manifestV1Validation(skillManifest as ISkillManifestV1, this.logger);
+                if (!this.logger.isError)
                 {
                     validVersion = manifestVersion.V1;
                     break;
@@ -69,7 +70,8 @@ Please make sure to provide a valid path to your Skill manifest using the '--loc
                 throw new Error('Your Skill Manifest is not compatible. Please note that the minimum supported manifest version is 2.1.');
             }
             case manifestVersion.V2: {
-                if (!manifestV2Validation(skillManifest as ISkillManifestV2, this.logger, this.configuration.endpointName).isError)
+                manifestV2Validation(skillManifest as ISkillManifestV2, this.logger, this.configuration.endpointName);
+                if (!this.logger.isError)
                 {
                     validVersion = manifestVersion.V2;
                     break;

--- a/tools/botskills/src/utils/index.ts
+++ b/tools/botskills/src/utils/index.ts
@@ -8,4 +8,4 @@ export { isAzPreviewMessage, isCloudGovernment, isValidAzVersion } from './azUti
 export { ChildProcessUtils } from './childProcessUtils';
 export { getDispatchNames } from './dispatchUtils';
 export { sanitizePath, wrapPathWithQuotes } from './sanitizationUtils';
-export { isValidCultures, validatePairOfArgs, isInstanceOfISkillManifestV1, isInstanceOfISkillManifestV2 } from './validationUtils';
+export { isValidCultures, validatePairOfArgs, manifestV1Validation, manifestV2Validation } from './validationUtils';

--- a/tools/botskills/src/utils/validationUtils.ts
+++ b/tools/botskills/src/utils/validationUtils.ts
@@ -44,7 +44,7 @@ export function isValidCultures(availableCultures: string[], targetedCultures: s
     return true;
 }
 
-export function manifestV1Validation(skillManifest: ISkillManifestV1, logger: ILogger): ILogger {
+export function manifestV1Validation(skillManifest: ISkillManifestV1, logger: ILogger): void {
     if (!skillManifest.name) {
         logger.error(`Missing property 'name' of the manifest`);
     }
@@ -65,10 +65,9 @@ export function manifestV1Validation(skillManifest: ISkillManifestV1, logger: IL
         logger.error(`Missing property 'actions' of the manifest`);
     }
 
-    return logger;
 }
 
-export function manifestV2Validation(skillManifest: ISkillManifestV2, logger: ILogger, endpointName?: string): ILogger {
+export function manifestV2Validation(skillManifest: ISkillManifestV2, logger: ILogger, endpointName?: string): void {
     if (!skillManifest.$schema) {
         logger.error(`Missing property '$schema' of the manifest`);
     }
@@ -105,5 +104,4 @@ export function manifestV2Validation(skillManifest: ISkillManifestV2, logger: IL
         logger.error(`Missing property 'activities' of the manifest`);
     }
     
-    return logger;
 }

--- a/tools/botskills/src/utils/validationUtils.ts
+++ b/tools/botskills/src/utils/validationUtils.ts
@@ -4,7 +4,8 @@
  */
 
 import { ISkillManifestV1 } from '../models/manifestV1/skillManifestV1';
-import { ISkillManifestV2 } from '../models/manifestV2/skillManifestV2';
+import { ISkillManifestV2, IEndpoint } from '../models/manifestV2/skillManifestV2';
+import { ILogger } from '../logger';
 
 /**
  * @param arg1 First argument of the pair of arguments.
@@ -43,27 +44,66 @@ export function isValidCultures(availableCultures: string[], targetedCultures: s
     return true;
 }
 
-export function isInstanceOfISkillManifestV1(skillManifest: ISkillManifestV1): boolean {
-    if (skillManifest.name === undefined ||
-        skillManifest.id === undefined ||
-        skillManifest.endpoint === undefined ||
-        skillManifest.authenticationConnections === undefined ||
-        skillManifest.actions === undefined ||
-        skillManifest.actions[0] === undefined) {
-        return false;
+export function manifestV1Validation(skillManifest: ISkillManifestV1, logger: ILogger): ILogger {
+    if (!skillManifest.name) {
+        logger.error(`Missing property 'name' of the manifest`);
+    }
+    if (!skillManifest.id) {
+        logger.error(`Missing property 'id' of the manifest`);
+    } else if (skillManifest.id.match(/^\d|[^\w]/g) !== null) {
+        logger.error(`The 'id' of the manifest contains some characters not allowed. Make sure the 'id' contains only letters, numbers and underscores, but doesn't start with number.`);
+    }
+    if (!skillManifest.endpoint) {
+        logger.error(`Missing property 'endpoint' of the manifest`);
+    } else if (skillManifest.endpoint.match(/^(https?:\/\/)?((([a-zA-F\d]([a-zA-F\d-]*[a-zA-F\d])*)\.)+[a-zA-F]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-zA-F\d%_.~+]*)*(\?[;&a-zA-F\d%_.~+=-]*)?(\#[-a-zA-F\d_]*)?$/g) === null) {
+        logger.error(`The 'endpoint' property contains some characters not allowed.`);
+    }
+    if (skillManifest.authenticationConnections === undefined || !skillManifest.authenticationConnections) {
+        logger.error(`Missing property 'authenticationConnections' of the manifest`);
+    }
+    if (!skillManifest.actions || skillManifest.actions === undefined || skillManifest.actions[0] === undefined) {
+        logger.error(`Missing property 'actions' of the manifest`);
     }
 
-    return true;
+    return logger;
 }
 
-export function isInstanceOfISkillManifestV2(skillManifest: ISkillManifestV2): boolean {
-    if (skillManifest.$schema === undefined ||
-        skillManifest.$id === undefined ||
-        skillManifest.endpoints === undefined ||
-        skillManifest.dispatchModels === undefined ||
-        skillManifest.activities === undefined || skillManifest.activities.size === 0) {
-        return false;
+export function manifestV2Validation(skillManifest: ISkillManifestV2, logger: ILogger, endpointName?: string): ILogger {
+    if (!skillManifest.$schema) {
+        logger.error(`Missing property '$schema' of the manifest`);
+    }
+    if (!skillManifest.$id) {
+        logger.error(`Missing property '$id' of the manifest`);
+    } else if (skillManifest.$id.match(/^\d|[^\w]/g) !== null) {
+        logger.error(`The '$id' of the manifest contains some characters not allowed. Make sure the '$id' contains only letters, numbers and underscores, but doesn't start with number.`);
+    }
+    if (!skillManifest.endpoints) {
+        logger.error(`Missing property 'endpoints' of the manifest`);
     }
 
-    return true;
+    let currentEndpoint = skillManifest.endpoints.find((endpoint): boolean =>  endpoint.name == endpointName) || skillManifest.endpoints[0];
+    if (!currentEndpoint.name){
+        logger.error(`Missing property 'name' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`);
+    }
+
+    if (!currentEndpoint.msAppId){
+        logger.error(`Missing property 'msAppId' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`);
+    } else if (currentEndpoint.msAppId.match(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/g) === null) {
+        logger.error(`The 'msAppId' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`);
+    }
+
+    if (!currentEndpoint.endpointUrl){
+        logger.error(`Missing property 'endpointUrl' at the selected endpoint. If you didn't select any endpoint, the first one is taken by default`);
+    } else if (currentEndpoint.endpointUrl.match(/^(https?:\/\/)?((([a-zA-F\d]([a-zA-F\d-]*[a-zA-F\d])*)\.)+[a-zA-F]{2,}|(((\d{1,3}\.){3}\d{1,3})|(localhost))(\:\d+)?)(\/[-a-zA-F\d%_.~+]*)*(\?[;&a-zA-F\d%_.~+=-]*)?(\#[-a-zA-F\d_]*)?$/g) === null) {
+        logger.error(`The 'endpointUrl' property contains some characters not allowed at the selected endpoint. If you didn't select any endpoint, the first one is taken by default.`);
+    }
+
+    if (!skillManifest.dispatchModels || skillManifest.dispatchModels === undefined) {
+        logger.error(`Missing property 'dispatchModels' of the manifest`);
+    }
+    if (!skillManifest.activities ||  Object.keys(skillManifest.activities).length === 0) {
+        logger.error(`Missing property 'activities' of the manifest`);
+    }
+    
+    return logger;
 }


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
In the previous validation, when an error occurred, the error wasn't detailed, so we added some changes to be more verbose when capturing an error.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
* When validating the manifests we used the `logger`  to show specific errors.
* Change the method `isInstanceOfISkillManifestV1` to `manifestV1Validation`.
* Change the method `isInstanceOfISkillManifestV2` to  `manifestV2Validation`.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
We will add tests for this methods.

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
