### PR TITLE
[Botskills] Fix refresh when the dispatch external calls fails

### DIFF
--- a/tools/botskills/test/refresh.test.js
+++ b/tools/botskills/test/refresh.test.js
@@ -114,10 +114,11 @@ Error: Path to the nonExistenceen-usDispatch.dispatch file leads to a nonexisten
             this.refresher.configuration = configuration;
             await this.refresher.refreshSkill(configuration);
             const errorList = this.logger.getError();
+            const localePlaceholder = errorList[errorList.length - 1].includes('en-us') ? 'en-us' : 'es-es';
 
             strictEqual(errorList[errorList.length - 1], `There was an error while refreshing any Skill from the Assistant:
 Error: There was an error in the dispatch refresh command:
-Command: dispatch refresh --dispatch ${configuration.dispatchFolder}\\en-us\\filleden-usDispatch.dispatch --dataFolder ${configuration.dispatchFolder}\\en-us
+Command: dispatch refresh --dispatch ${configuration.dispatchFolder}\\${ localePlaceholder }\\filled${ localePlaceholder }Dispatch.dispatch --dataFolder ${configuration.dispatchFolder}\\${ localePlaceholder }
 Error: Mocked function throws an Error`);
         });
 


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
