### PR TITLE
[Botskills] Add verifyLuisFolder functionality

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { isAbsolute, join, resolve } from 'path';
 import { get } from 'request-promise-native';
 import { ConsoleLogger, ILogger } from '../logger';
@@ -92,6 +92,7 @@ export class ConnectSkill {
                         let luisAppName: string = currentApp.url.split('/').reverse()[0];
 
                         const luPath = join(this.configuration.luisFolder, culture, luisAppName.endsWith('.lu') ? luisAppName : luisAppName + '.lu');
+                        this.verifyLuisFolder(culture);
                         writeFileSync(luPath, remoteLuFile);
                         luFilePath = luPath;
                     } catch (error) {
@@ -242,6 +243,16 @@ Please make sure to provide a valid path to your Skill manifest using the '--loc
         }
 
         return JSON.parse(readFileSync(skillManifestPath, 'UTF8'));
+    }
+
+    private verifyLuisFolder(culture: string): void {
+        if (!existsSync(this.configuration.luisFolder)){
+            mkdirSync(this.configuration.luisFolder);
+        }
+
+        if (!existsSync(join(this.configuration.luisFolder, culture))) {
+            mkdirSync(join(this.configuration.luisFolder, culture));
+        }
     }
 
     private async validateCultures(cognitiveModelsFile: ICognitiveModel, luisDictionary: Map<string, string[]>): Promise<void> {


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
Since the `luisFolder` wasn't being verified before use, if the folder wasn't exists, `botskills` was throwing an error. With this PR, the `luisFolder` is verified and in the case that doesn't exists, is created.

### Changes
* Add the `verifyLuisFolder` method.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
We will add tests for this functionality

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
