### PR TITLE
[Botskills] Fix casing of the Skill's properties in the appsettings.json

### DIFF
--- a/docs/_docs/help/known-issues.md
+++ b/docs/_docs/help/known-issues.md
@@ -13,19 +13,20 @@ toc: true
 If you experience a HTTP 401 (authentication) error when invoking a Skill with an exception message as shown:
      `Exception Message: Error invoking the skill id: "SKILL_ID" at "https://SKILL_APP_SERVICE.azurewebsites.net/api/messages" (status is 401)`
 
-Validate your parent Bot (e.g. Virtual Assistant) `appSettings.json file` has a correctly populated `BotFrameworkSkills` section. For example you should see a complete fragment like the one shown below with the `AppId` of each configured Skill. This should be populated automatically by the `botskills` CLI.
+Validate your parent Bot (e.g. Virtual Assistant) `appSettings.json file` has a correctly populated `botFrameworkSkills` section. For example you should see a complete fragment like the one shown below with the `appId` of each configured Skill. This should be populated automatically by the `botskills` CLI.
 
 ```json
 {
-"BotFrameworkSkills" : [
+"botFrameworkSkills" : [
     {
-        "Id": "calendarSkill",
-        "Name": "calendarSkill",
-        "AppId": "SkillAppId",
-        "SkillEndpoint": "https://yourSkillAppService.azurewebsites.net/api/messages",
+        "id": "calendarSkill",
+        "name": "calendarSkill",
+        "description": "The Calendar skill provides calendaring related capabilities and supports Office and Google calendars.",
+        "appId": "SkillAppId",
+        "skillEndpoint": "https://yourSkillAppService.azurewebsites.net/api/messages",
 
     }],
-    "SkillHostEndpoint": "https://yourVAAppService.azurewebsites.net/api/skills"
+    "skillHostEndpoint": "https://yourVAAppService.azurewebsites.net/api/skills"
 }
 
 ```
@@ -34,13 +35,13 @@ Validate your parent Bot (e.g. Virtual Assistant) `appSettings.json file` has a 
 If you experience a HTTP 500 (server error) error when invoking a Skill with an exception message as shown:
      `Exception Message: Error invoking the skill id: "SKILL_ID" at "https://SKILL_APP_SERVICE.azurewebsites.net/api/messages" (status is 500)`
 
-Validate your parent Bot (e.g. Virtual Assistant) `appSettings.json file` has a valid `SkillHostEndpoint` which should be pointing at the URL of your Parent Bot (e.g. Virtual Assistant) with a suffix of `/api/skills` as per the example below. Skills connect back to the caller through this endpoint.
+Validate your parent Bot (e.g. Virtual Assistant) `appSettings.json file` has a valid `skillHostEndpoint` which should be pointing at the URL of your Parent Bot (e.g. Virtual Assistant) with a suffix of `/api/skills` as per the example below. Skills connect back to the caller through this endpoint.
 
 ```json
 {
-"BotFrameworkSkills" : [
+"botFrameworkSkills" : [
     { }],
-    "SkillHostEndpoint": "https://yourVAAppService.azurewebsites.net/api/skills"
+    "skillHostEndpoint": "https://yourVAAppService.azurewebsites.net/api/skills"
 }
 ```
 
@@ -48,7 +49,7 @@ If you are debugging a parent bot locally and invoking a Skill remotely you will
 
 1. Start a debugging session for your Virtual Assistant and make a note of the port it's hosted on (e.g. 3978)
 1. Assuming port 3978 run this command:L `ngrok.exe http 3978 -host-header="localhost:3978"`
-1. Retrieve the https forwarding URL (e.g. https:{name}.ngrok.io) and update `SkillHostEndpoint` with this URL suffixed with `/api/skills`
+1. Retrieve the https forwarding URL (e.g. https:{name}.ngrok.io) and update `skillHostEndpoint` with this URL suffixed with `/api/skills`
 1. Now, when a remote skill is invoked it will route all responses back to `https:{name}.ngrok.io` which will then tunnel responses back to your Virtual Assistant
 
 ## My Microsoft App Registration could not be automatically provisioned

--- a/docs/_docs/overview/whats-new/0.8-beta/migrate-existing-va-to-0.8.md
+++ b/docs/_docs/overview/whats-new/0.8-beta/migrate-existing-va-to-0.8.md
@@ -394,12 +394,14 @@ The Virtual Assistant you are migrating from has to be created with the Virtual 
             {
                 "id": "{Skill1}",
                 "name": "{Skill1}",
+                "description": "{Skill1Description}",
                 "appId": "{Skill1MsAppId}",
                 "skillEndpoint": "https://{Skill1Endpoint}/api/messages"
             },
             {
                 "id": "{Skill2}",
                 "name": "{Skill2}",
+                "description": "{Skill2Description}",
                 "appId": "{Skill2MsAppId}",
                 "skillEndpoint": "https://{Skill1Endpoint}/api/messages"
             }]

--- a/docs/_docs/overview/whats-new/0.8-beta/migrate-existing-va-to-0.8.md
+++ b/docs/_docs/overview/whats-new/0.8-beta/migrate-existing-va-to-0.8.md
@@ -389,19 +389,19 @@ The Virtual Assistant you are migrating from has to be created with the Virtual 
 
     ```json
     {
-        "SkillHostEndpoint": "https://{yourvirtualassistant}.azurewebsites.net/api/skills/",
-        "BotFrameworkSkills": [
+        "skillHostEndpoint": "https://{yourvirtualassistant}.azurewebsites.net/api/skills/",
+        "botFrameworkSkills": [
             {
-                "Id": "{Skill1}",
-                "Name": "{Skill1}",
-                "AppId": "{Skill1MsAppId}",
-                "SkillEndpoint": "https://{Skill1Endpoint}/api/messages"
+                "id": "{Skill1}",
+                "name": "{Skill1}",
+                "appId": "{Skill1MsAppId}",
+                "skillEndpoint": "https://{Skill1Endpoint}/api/messages"
             },
             {
-                "Id": "{Skill2}",
-                "Name": "{Skill2}",
-                "AppId": "{Skill2MsAppId}",
-                "SkillEndpoint": "https://{Skill1Endpoint}/api/messages"
+                "id": "{Skill2}",
+                "name": "{Skill2}",
+                "appId": "{Skill2MsAppId}",
+                "skillEndpoint": "https://{Skill1Endpoint}/api/messages"
             }]
     }
     ```

--- a/docs/_docs/skills/handbook/add-skills-to-a-virtual-assistant.md
+++ b/docs/_docs/skills/handbook/add-skills-to-a-virtual-assistant.md
@@ -59,7 +59,8 @@ Once the connect command finish successfully, you can see under the `botFramewor
         "id": "<SKILL_ID>",
         "appId": "<SKILL_APPID>",
         "skillEndpoint": "<SKILL_ENDPOINT>",
-        "name": "<SKILL_NAME>"
+        "name": "<SKILL_NAME>",
+        "description": "<SKILL_DESCRIPTION>"
     },
     "skillHostEndpoint": "<VA-SKILL_ENDPOINT>"
 ```

--- a/docs/_docs/skills/handbook/add-skills-to-a-virtual-assistant.md
+++ b/docs/_docs/skills/handbook/add-skills-to-a-virtual-assistant.md
@@ -52,16 +52,16 @@ The `--luisFolder` parameter can be used to point the Skill CLI at the source LU
 botskills connect --remoteManifest "{{site.data.urls.SkillManifest}}" --cs
 ```
 
-Once the connect command finish successfully, you can see under the `BotFrameworkSkills` property of your Virtual Assistant's appsettings.json file that the following structure was added with the information provided in the Skill manifest.
+Once the connect command finish successfully, you can see under the `botFrameworkSkills` property of your Virtual Assistant's appsettings.json file that the following structure was added with the information provided in the Skill manifest.
 
 ```json
-    "BotFrameworkSkills": {
-        "Id": "<SKILL_ID>",
-        "AppId": "<SKILL_APPID>",
-        "SkillEndpoint": "<SKILL_ENDPOINT>",
-        "Name": "<SKILL_NAME>"
+    "botFrameworkSkills": {
+        "id": "<SKILL_ID>",
+        "appId": "<SKILL_APPID>",
+        "skillEndpoint": "<SKILL_ENDPOINT>",
+        "name": "<SKILL_NAME>"
     },
-    "SkillHostEndpoint": "<VA-SKILL_ENDPOINT>"
+    "skillHostEndpoint": "<VA-SKILL_ENDPOINT>"
 ```
 
 See the [Skill CLI documentation]({{site.baseurl}}/skills/handbook/botskills) for detailed CLI documentation.

--- a/docs/_docs/skills/handbook/botskills.md
+++ b/docs/_docs/skills/handbook/botskills.md
@@ -46,16 +46,16 @@ botskills connect --remoteManifest "{{site.data.urls.SkillManifest}}" --cs
 
 *Remember to re-publish your Assistant to Azure after you've added a Skill unless you plan on testing locally only*
 
-Once the connect command finish successfully, you can see under the `BotFrameworkSkills` property of your Virtual Assistant's appsettings.json file that the following structure was added with the information provided in the Skill manifest.
+Once the connect command finish successfully, you can see under the `botFrameworkSkills` property of your Virtual Assistant's appsettings.json file that the following structure was added with the information provided in the Skill manifest.
 
 ```json
-    "BotFrameworkSkills": {
-        "Id": "<SKILL_ID>",
-        "AppId": "<SKILL_APPID>",
-        "SkillEndpoint": "<SKILL_ENDPOINT>",
-        "Name": "<SKILL_NAME>"
+    "botFrameworkSkills": {
+        "id": "<SKILL_ID>",
+        "appId": "<SKILL_APPID>",
+        "skillEndpoint": "<SKILL_ENDPOINT>",
+        "name": "<SKILL_NAME>"
     },
-    "SkillHostEndpoint": "<VA-SKILL_ENDPOINT>"
+    "skillHostEndpoint": "<VA-SKILL_ENDPOINT>"
 ```
 
 For further information, see the [Connect command documentation]({{site.repo}}/tree/master/tools/botskills/docs/connect.md).

--- a/docs/_docs/skills/handbook/botskills.md
+++ b/docs/_docs/skills/handbook/botskills.md
@@ -53,7 +53,8 @@ Once the connect command finish successfully, you can see under the `botFramewor
         "id": "<SKILL_ID>",
         "appId": "<SKILL_APPID>",
         "skillEndpoint": "<SKILL_ENDPOINT>",
-        "name": "<SKILL_NAME>"
+        "name": "<SKILL_NAME>",
+        "description": "<SKILL_DESCRIPTION>"
     },
     "skillHostEndpoint": "<VA-SKILL_ENDPOINT>"
 ```

--- a/docs/_docs/virtual-assistant/handbook/devops.md
+++ b/docs/_docs/virtual-assistant/handbook/devops.md
@@ -73,4 +73,4 @@ Once you have updated your manifest, follow these steps to update any Virtual As
 botskills update --remoteManifest "http://<YOUR_SKILL_MANIFEST>.azurewebsites.net/api/skill/manifest" --cs
 ```
 
-> This command updates the BotFrameworkSkills property of your appsettings.json file with the latest manifest definitions for each connected skill, and runs dispatch refresh to update your dispatch model.
+> This command updates the botFrameworkSkills property of your appsettings.json file with the latest manifest definitions for each connected skill, and runs dispatch refresh to update your dispatch model.

--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -415,12 +415,13 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
         if (this.skillManifestValidated == manifestVersion.V1) {
             const skillManifestV1: ISkillManifestV1 = skill as ISkillManifestV1;
             assistantSkills.push({
-                Id: skillManifestV1.id,
-                AppId: skillManifestV1.msaAppId,
-                SkillEndpoint: skillManifestV1.endpoint,
-                Name: skillManifestV1.name
+                id: skillManifestV1.id,
+                appId: skillManifestV1.msaAppId,
+                skillEndpoint: skillManifestV1.endpoint,
+                name: skillManifestV1.name,
+                description: skillManifestV1.description
             });
-            assistantSkillsFile.BotFrameworkSkills = assistantSkills;
+            assistantSkillsFile.botFrameworkSkills = assistantSkills;
         }
 
         if (this.skillManifestValidated == manifestVersion.V2) {
@@ -429,17 +430,18 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
             || skillManifestV2.endpoints[0];
             
             assistantSkills.push({
-                Id: skillManifestV2.$id,
-                AppId: endpoint.msAppId,
-                SkillEndpoint: endpoint.endpointUrl,
-                Name: skillManifestV2.name,
+                id: skillManifestV2.$id,
+                appId: endpoint.msAppId,
+                skillEndpoint: endpoint.endpointUrl,
+                name: skillManifestV2.name,
+                description: skillManifestV2.description
             });
-            assistantSkillsFile.BotFrameworkSkills = assistantSkills;
+            assistantSkillsFile.botFrameworkSkills = assistantSkills;
         }
         
-        if (assistantSkillsFile.SkillHostEndpoint === undefined || assistantSkillsFile.SkillHostEndpoint.trim().length === 0) {
+        if (assistantSkillsFile.skillHostEndpoint === undefined || assistantSkillsFile.skillHostEndpoint.trim().length === 0) {
             const channel: string = await isCloudGovernment() ? 'us' : 'net';
-            assistantSkillsFile.SkillHostEndpoint = `https://${ this.configuration.botName }.azurewebsites.${ channel }/api/skills`;
+            assistantSkillsFile.skillHostEndpoint = `https://${ this.configuration.botName }.azurewebsites.${ channel }/api/skills`;
         }
         writeFileSync(this.configuration.appSettingsFile, JSON.stringify(assistantSkillsFile, undefined, 4));
     }
@@ -448,10 +450,10 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
         try {
             // Take VA Skills configurations
             const assistantSkillsFile: IAppSetting = JSON.parse(readFileSync(this.configuration.appSettingsFile, 'UTF8'));
-            const assistantSkills: ISkill[] = assistantSkillsFile.BotFrameworkSkills !== undefined ? assistantSkillsFile.BotFrameworkSkills : [];
+            const assistantSkills: ISkill[] = assistantSkillsFile.botFrameworkSkills !== undefined ? assistantSkillsFile.botFrameworkSkills : [];
 
             // Check if the skill is already connected to the assistant
-            if (assistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.Id === skillManifest.id)) {
+            if (assistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.id === skillManifest.id)) {
                 this.logger.warning(`The skill '${skillManifest.name}' is already registered.`);
                 return;
             }
@@ -482,10 +484,10 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
         try {
             // Take VA Skills configurations
             const assistantSkillsFile: IAppSetting = JSON.parse(readFileSync(this.configuration.appSettingsFile, 'UTF8'));
-            const assistantSkills: ISkill[] = assistantSkillsFile.BotFrameworkSkills !== undefined ? assistantSkillsFile.BotFrameworkSkills : [];
+            const assistantSkills: ISkill[] = assistantSkillsFile.botFrameworkSkills !== undefined ? assistantSkillsFile.botFrameworkSkills : [];
 
             // Check if the skill is already connected to the assistant
-            if (assistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.Id === skillManifest.$id)) {
+            if (assistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.id === skillManifest.$id)) {
                 this.logger.warning(`The skill '${skillManifest.name}' is already registered.`);
                 return;
             }

--- a/tools/botskills/src/functionality/disconnectSkill.ts
+++ b/tools/botskills/src/functionality/disconnectSkill.ts
@@ -98,11 +98,11 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
 
             // Take VA Skills configurations
             const assistantSkillsFile: IAppSetting = JSON.parse(readFileSync(this.configuration.appSettingsFile, 'UTF8'));
-            const assistantSkills: ISkill[] = assistantSkillsFile.BotFrameworkSkills !== undefined ? assistantSkillsFile.BotFrameworkSkills : [];
+            const assistantSkills: ISkill[] = assistantSkillsFile.botFrameworkSkills !== undefined ? assistantSkillsFile.botFrameworkSkills : [];
 
             // Check if the skill is present in the assistant
             const skillToRemove: ISkill | undefined = assistantSkills.find((assistantSkill: ISkill): boolean =>
-                assistantSkill.Id === this.configuration.skillId
+                assistantSkill.id === this.configuration.skillId
             );
 
             if (!skillToRemove) {
@@ -128,7 +128,7 @@ Please make sure to provide a valid path to your LUISGen output folder using the
                 assistantSkills.splice(assistantSkills.indexOf(skillToRemove), 1);
 
                 // Updating the assistant skills file's skills property with the assistant skills array
-                assistantSkillsFile.BotFrameworkSkills = assistantSkills;
+                assistantSkillsFile.botFrameworkSkills = assistantSkills;
 
                 // Writing (and overriding) the assistant skills file
                 writeFileSync(this.configuration.appSettingsFile, JSON.stringify(assistantSkillsFile, undefined, 4));

--- a/tools/botskills/src/functionality/listSkill.ts
+++ b/tools/botskills/src/functionality/listSkill.ts
@@ -23,12 +23,12 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
             }
             // Take VA Skills configurations
             const assistantAppSettingsFile: IAppSetting = JSON.parse(readFileSync(configuration.appSettingsFile, 'UTF8'));
-            if (assistantAppSettingsFile.BotFrameworkSkills === undefined) {
+            if (assistantAppSettingsFile.botFrameworkSkills === undefined) {
                 this.logger.message('There are no Skills connected to the assistant.');
 
                 return false;
             }
-            const assistantSkills: ISkill[] = assistantAppSettingsFile.BotFrameworkSkills;
+            const assistantSkills: ISkill[] = assistantAppSettingsFile.botFrameworkSkills;
 
             if (assistantSkills.length < 1) {
                 this.logger.message('There are no Skills connected to the assistant.');
@@ -37,7 +37,7 @@ Please make sure to provide a valid path to your Assistant Skills configuration 
             } else {
                 let message: string = `The skills already connected to the assistant are the following:`;
                 assistantSkills.forEach((skillManifest: ISkill): void => {
-                    message += `\n\t- ${skillManifest.Id}`;
+                    message += `\n\t- ${skillManifest.id}`;
                 });
 
                 this.logger.message(message);

--- a/tools/botskills/src/functionality/updateSkill.ts
+++ b/tools/botskills/src/functionality/updateSkill.ts
@@ -114,9 +114,9 @@ Please make sure to provide a valid path to your Skill manifest using the '--loc
             }
 
             const assistantSkillsFile: IAppSetting = JSON.parse(readFileSync(this.configuration.appSettingsFile, 'UTF8'));
-            const assistantSkills: ISkill[] = assistantSkillsFile.BotFrameworkSkills !== undefined ? assistantSkillsFile.BotFrameworkSkills : [];
+            const assistantSkills: ISkill[] = assistantSkillsFile.botFrameworkSkills !== undefined ? assistantSkillsFile.botFrameworkSkills : [];
             // Check if the skill is already connected to the assistant
-            if (assistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.Id === skillId)) {
+            if (assistantSkills.find((assistantSkill: ISkill): boolean => assistantSkill.id === skillId)) {
                 this.configuration.skillId = skillId;
 
                 return true;

--- a/tools/botskills/src/models/appSetting.ts
+++ b/tools/botskills/src/models/appSetting.ts
@@ -12,6 +12,6 @@ export interface IAppSetting {
     microsoftAppPassword: string;
     botWebAppName: string;
     resourceGroupName: string;
-    BotFrameworkSkills?: ISkill[];
-    SkillHostEndpoint?: string;
+    botFrameworkSkills?: ISkill[];
+    skillHostEndpoint?: string;
 }

--- a/tools/botskills/src/models/skill.ts
+++ b/tools/botskills/src/models/skill.ts
@@ -4,8 +4,9 @@
  */
 
 export interface ISkill {
-    Id: string;
-    AppId: string;
-    SkillEndpoint: string;
-    Name: string;
+    id: string;
+    appId: string;
+    skillEndpoint: string;
+    name: string;
+    description: string;
 }


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
The TypeScript's properties are lowerCamelCase, and using UpperCamelCase in the `appsettings.json` for the skill's properties will break the solution as TypeScript is case sensitive.
Also, the `description` property was needed in [EnhancedBotFrameworkSkill](https://github.com/microsoft/botframework-solutions/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Skills/Models/EnhancedBotFrameworkSkill.cs#L14) interface for C# and TypeScript.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Make skill properties casing to lowerCamelCase in the `appsettings.json` file
- Add `description` property in the Skill model
- Update documentation

![image](https://user-images.githubusercontent.com/11904023/76539524-a5874d80-645f-11ea-92e0-63f2cc100e4c.png)

![image](https://user-images.githubusercontent.com/11904023/76539530-a7e9a780-645f-11ea-99ae-4cfd86564423.png)

![image](https://user-images.githubusercontent.com/11904023/76539541-ab7d2e80-645f-11ea-8681-b325f42356b3.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [X] I have updated related documentation
