### PR TITLE
[TypeScript][Virtual Assistant & Skill] Add lowerCaseLng config to i18next

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/index.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/index.ts
@@ -47,6 +47,7 @@ import { AllowedCallersClaimsValidator } from './authentication/allowedCallersCl
 // Configure internationalization and default locale
 i18next.use(i18nextNodeFsBackend)
     .init({
+        lowerCaseLng: true,
         fallbackLng: 'en-us',
         preload: ['de-de', 'en-us', 'es-es', 'fr-fr', 'it-it', 'zh-cn'],
         backend: {

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/src/index.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/src/index.ts
@@ -40,6 +40,7 @@ import { IBotSettings } from './services/botSettings';
 // Configure internationalization and default locale
 i18next.use(i18nextNodeFsBackend)
     .init({
+        lowerCaseLng: true,
         fallbackLng: 'en-us',
         preload: ['de-de', 'en-us', 'es-es', 'fr-fr', 'it-it', 'zh-cn']
     })

--- a/templates/typescript/samples/sample-assistant/src/index.ts
+++ b/templates/typescript/samples/sample-assistant/src/index.ts
@@ -47,6 +47,7 @@ import { AllowedCallersClaimsValidator } from './authentication/allowedCallersCl
 // Configure internationalization and default locale
 i18next.use(i18nextNodeFsBackend)
     .init({
+        lowerCaseLng: true,
         fallbackLng: 'en-us',
         preload: ['de-de', 'en-us', 'es-es', 'fr-fr', 'it-it', 'zh-cn'],
         backend: {

--- a/templates/typescript/samples/sample-skill/src/index.ts
+++ b/templates/typescript/samples/sample-skill/src/index.ts
@@ -40,6 +40,7 @@ import { IBotSettings } from './services/botSettings';
 // Configure internationalization and default locale
 i18next.use(i18nextNodeFsBackend)
     .init({
+        lowerCaseLng: true,
         fallbackLng: 'en-us',
         preload: ['de-de', 'en-us', 'es-es', 'fr-fr', 'it-it', 'zh-cn']
     })


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Makes `i18next` use **lowercase language codes** to avoid case sensitiviness issues.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Adds a configuration option for i18next to use language codes in lower case. This configuration is replicated to the Virtual Assistant and Skill Template and Sample

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
