### PR TITLE
[Botskills] Fix DispatchLuis not being overwritten

### DIFF
--- a/tools/botskills/src/botskills-connect.ts
+++ b/tools/botskills/src/botskills-connect.ts
@@ -139,7 +139,7 @@ luisFolder = args.luisFolder ? sanitizePath(args.luisFolder) : join(outFolder, '
 dispatchFolder = args.dispatchFolder ? sanitizePath(args.dispatchFolder) : join(outFolder, 'Deployment', 'Resources', 'Dispatch');
 
 // lgOutFolder validation
-lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services', 'DispatchLuis.ts') : join('Services', 'DispatchLuis.cs')));
 
 // Initialize an instance of IConnectConfiguration to send the needed arguments to the connectSkill function
 const configuration: IConnectConfiguration = {

--- a/tools/botskills/src/botskills-disconnect.ts
+++ b/tools/botskills/src/botskills-disconnect.ts
@@ -111,7 +111,7 @@ dispatchFolder = args.dispatchFolder ?
 
 // lgOutFolder validation
 lgOutFolder = args.lgOutFolder ?
-    sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+    sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services', 'DispatchLuis.ts') : join('Services', 'DispatchLuis.cs')));
 
 // End of arguments validation
 // Initialize an instance of IDisconnectConfiguration to send the needed arguments to the disconnectSkill function

--- a/tools/botskills/src/botskills-refresh.ts
+++ b/tools/botskills/src/botskills-refresh.ts
@@ -76,7 +76,7 @@ cognitiveModelsFile = args.cognitiveModelsFile || join(outFolder, (args.ts ? joi
 dispatchFolder = args.dispatchFolder ? sanitizePath(args.dispatchFolder) : join(outFolder, 'Deployment', 'Resources', 'Dispatch');
 
 // lgOutFolder validation
-lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services', 'DispatchLuis.ts') : join('Services', 'DispatchLuis.cs')));
 
 // End of arguments validation
 

--- a/tools/botskills/src/botskills-update.ts
+++ b/tools/botskills/src/botskills-update.ts
@@ -139,7 +139,7 @@ luisFolder = args.luisFolder ? sanitizePath(args.luisFolder) : join(outFolder, '
 dispatchFolder = args.dispatchFolder ? sanitizePath(args.dispatchFolder) : join(outFolder, 'Deployment', 'Resources', 'Dispatch');
 
 // lgOutFolder validation
-lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services') : 'Services'));
+lgOutFolder = args.lgOutFolder ? sanitizePath(args.lgOutFolder) : join(outFolder, (args.ts ? join('src', 'Services', 'DispatchLuis.ts') : join('Services', 'DispatchLuis.cs')));
 
 // End of arguments validation
 

--- a/tools/botskills/src/functionality/refreshSkill.ts
+++ b/tools/botskills/src/functionality/refreshSkill.ts
@@ -70,6 +70,9 @@ export class RefreshSkill {
                 const argumentValue: string = executionModelByCulture.get(argument) as string;
                 luisGenerateCommand.push(...[argument, argumentValue]);
             });
+
+            // Force the bf luis:generate to overwrite the output file if it already exists
+            luisGenerateCommand.push('--force');
             await this.runCommand(luisGenerateCommand, `Executing luisgen for the ${ dispatchName } file`);
         } catch (err) {
             throw new Error(`There was an error in the bf luis:generate:${ this.configuration.lgLanguage } command:\nCommand: ${ luisGenerateCommand.join(' ') }\n${ err }`);

--- a/tools/botskills/test/refresh.test.js
+++ b/tools/botskills/test/refresh.test.js
@@ -144,7 +144,7 @@ Error: Mocked function throws an Error`);
 
             strictEqual(errorList[errorList.length - 1], `There was an error while refreshing any Skill from the Assistant:
 Error: There was an error in the bf luis:generate:${configuration.lgLanguage} command:
-Command: bf luis:generate:${configuration.lgLanguage} --in "${configuration.dispatchFolder}\\en-us\\filleden-usDispatch.json" --out "${configuration.lgOutFolder}"
+Command: bf luis:generate:${configuration.lgLanguage} --in "${configuration.dispatchFolder}\\en-us\\filleden-usDispatch.json" --out "${configuration.lgOutFolder}" --force
 Error: Mocked function throws an Error`);
         });
     });


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Botskills is not overwriting the `DispatchLuis` file after connecting a Skill to a VA.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Add `DispatchLuis` to the default `--lgOutFolder` value.
- Add `--force` flag to the `bf luis:generate` command.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
One test is updated with the `--force` flag.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
