### PR TITLE
[TypeScript][Virtual Assistant] Fix QnA validation after port #3372

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/mainDialog.ts
@@ -182,7 +182,7 @@ export class MainDialog extends ComponentDialog {
         }
 
         // QnAMaker dialog already present on the stack?
-        if (this.dialogs.find(knowledgebaseId) !== undefined) {
+        if (this.dialogs.find(knowledgebaseId) === undefined) {
             return new QnAMakerDialog(
                 qnaEndpoint.knowledgeBaseId,
                 qnaEndpoint.endpointKey,

--- a/templates/typescript/samples/sample-assistant/src/dialogs/mainDialog.ts
+++ b/templates/typescript/samples/sample-assistant/src/dialogs/mainDialog.ts
@@ -182,7 +182,7 @@ export class MainDialog extends ComponentDialog {
         }
 
         // QnAMaker dialog already present on the stack?
-        if (this.dialogs.find(knowledgebaseId) !== undefined) {
+        if (this.dialogs.find(knowledgebaseId) === undefined) {
             return new QnAMakerDialog(
                 qnaEndpoint.knowledgeBaseId,
                 qnaEndpoint.endpointKey,


### PR DESCRIPTION
Related to 3372 
### Purpose
*What is the context of this pull request? Why is it being done?*
The PR 3372 introduces an issue when a new QnA Dialog is added.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- If there is not an specific knowledgeBaseId already created, the knowledgeBase is added in the dialogs.

We took into account the C# [implementation](https://github.com/microsoft/botframework-solutions/blob/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs#L182)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
