### PR TITLE
[TypeScript] Add build props in the Samples and Templates

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/resources/template.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/resources/template.json
@@ -277,6 +277,18 @@
             {
               "name": "MicrosoftAppPassword",
               "value": "[parameters('microsoftAppPassword')]"
+            },
+            {
+              "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+              "value": true
+            },
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "12.15.0"
+            },
+            {
+              "name": "NODE_PATH",
+              "value": "D:/home/site/wwwroot/node_modules"
             }
           ]
         }

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/resources/template.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/resources/template.json
@@ -227,6 +227,18 @@
             {
               "name": "MicrosoftAppPassword",
               "value": "[parameters('microsoftAppPassword')]"
+            },
+            {
+              "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+              "value": true
+            },
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "12.15.0"
+            },
+            {
+              "name": "NODE_PATH",
+              "value": "D:/home/site/wwwroot/node_modules"
             }
           ]
         }

--- a/templates/typescript/samples/sample-assistant/deployment/resources/template.json
+++ b/templates/typescript/samples/sample-assistant/deployment/resources/template.json
@@ -277,6 +277,18 @@
             {
               "name": "MicrosoftAppPassword",
               "value": "[parameters('microsoftAppPassword')]"
+            },
+            {
+              "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+              "value": true
+            },
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "12.15.0"
+            },
+            {
+              "name": "NODE_PATH",
+              "value": "D:/home/site/wwwroot/node_modules"
             }
           ]
         }

--- a/templates/typescript/samples/sample-skill/deployment/resources/template.json
+++ b/templates/typescript/samples/sample-skill/deployment/resources/template.json
@@ -227,6 +227,18 @@
             {
               "name": "MicrosoftAppPassword",
               "value": "[parameters('microsoftAppPassword')]"
+            },
+            {
+              "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+              "value": true
+            },
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "12.15.0"
+            },
+            {
+              "name": "NODE_PATH",
+              "value": "D:/home/site/wwwroot/node_modules"
             }
           ]
         }


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
The `node_modules` folder is not created in Kudu after the bot is published using `publish.ps1`

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
The following changes were added in the Virtual Assistant and the Skill `template.json` file of TypeScript:

- Add `SCM_DO_BUILD_DURING_DEPLOYMENT` to **true**
- Add `WEBSITE_NODE_DEFAULT_VERSION` to **12.15.0**
- Add `NODE_PATH` to the **node_modules** folder
- Replicate to Templates

![image](https://user-images.githubusercontent.com/11904023/83042163-b46dad00-a017-11ea-8107-bf6386a51352.png)

![image](https://user-images.githubusercontent.com/11904023/83042173-b7689d80-a017-11ea-8a04-11e038daa945.png)


### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-
### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
