### PR TITLE
[TypeScript][Generator] Fix cognitivemodel mocks values

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/src/copier.js
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/src/copier.js
@@ -88,10 +88,6 @@ class Copier {
       join(`src`, `manifest`, `_manifest-1.1.json`),
       join(`src`, `manifest`, `manifest-1.1.json`)
     );
-    templateFiles.set(
-      join(`test`, `mocks`, `resources`, `_cognitiveModels.json`),
-      join(`test`, `mocks`, `resources`, `cognitiveModels.json`)
-    );
     selectedLanguages.forEach(language => {
       templateFiles.set(
         join(`deployment`, `resources`, `LU`, language, `_skill.lu`),

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/mocks/resources/cognitiveModels.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/test/mocks/resources/cognitiveModels.json
@@ -22,13 +22,13 @@
           "name": "general"
         },
         {
-          "id": "<%=skillNameCamelCase%>",
+          "id": "sampleSkill",
           "authoringRegion": "westus",
           "appId": "00000002-0000-0000-0000-000000000001",
           "authoringKey": "<--MOCK-VALUE-->",
           "version": "0.1",
           "subscriptionKey": "<--MOCK-VALUE-->",
-          "name": "<%=skillNameCamelCase%>",
+          "name": "sampleSkill",
           "region": "westus"
         }
       ]

--- a/templates/typescript/generator-bot-virtualassistant/test/generator-bot-virtualassistant.skill.test.suite.js
+++ b/templates/typescript/generator-bot-virtualassistant/test/generator-bot-virtualassistant.skill.test.suite.js
@@ -27,7 +27,6 @@ describe(`The generator-bot-virtualassistant skill tests`, function() {
     var manifest1_1;
     const manifestPath1_0 = join(`src`, `manifest`, `manifest-1.0.json`);
     const manifestPath1_1 = join(`src`, `manifest`, `manifest-1.1.json`);
-    const testCognitiveModelsPath = join(`test`, `mocks`, `resources`, `cognitiveModels.json`);
 
     const templatesFiles = [
         `package.json`,
@@ -36,7 +35,6 @@ describe(`The generator-bot-virtualassistant skill tests`, function() {
         `.nycrc`,
         manifestPath1_0,
         manifestPath1_1,
-        testCognitiveModelsPath
     ];
 
     const commonDirectories = [
@@ -196,24 +194,6 @@ describe(`The generator-bot-virtualassistant skill tests`, function() {
 
             it(`a description property with given description`, function(done) {
                 assert.strictEqual(packageJSON.description, skillDesc);
-                done();
-            });
-        });
-        
-        describe(`and have in the cognitiveModels file`, function() {
-            it(`an id property with the given name`, function(done) {
-                assert.fileContent(
-                  join(skillGenerationPath, skillName, testCognitiveModelsPath),
-                  `"id": "${skillNameCamelCase}",`
-                );
-                done();
-            });
-
-            it(`a name property with the given name`, function(done) {
-                assert.fileContent(
-                  join(skillGenerationPath, skillName, testCognitiveModelsPath),
-                  `"name": "${skillNameCamelCase}",`
-                );
                 done();
             });
         });


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Closes the PR#XXXX

The generator was creating skills with failing tests when the name of the skill was different to `sample-skill`.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
As the test values are mocked we added the `sampleSkill` value as the name and id of the skill in the tests.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-
### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist
\-

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
