### PR TITLE
[PORT 3262][Botskills] Show all language output when there's an issue with a LU file

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -214,7 +214,7 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
                 throw new Error(`Path to ${ luisFile } (${ luisFilePath }) leads to a nonexistent file.`);
             }
         } catch (err) {
-            throw new Error(`There was an error in the bf luis:convert command:\nCommand: ${ luisConvertCommand.join(' ') }\n${ err }`);
+            this.logger.error(`There was an error in the bf luis:convert command:\nCommand: ${ luisConvertCommand.join(' ') }\n${ err }`);
         }
     }
 
@@ -236,7 +236,7 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
             });
             await this.runCommand(dispatchAddCommand, `Executing dispatch add for the ${ culture } ${ luisApp } LU file`);
         } catch (err) {
-            throw new Error(`There was an error in the dispatch add command:\nCommand: ${ dispatchAddCommand.join(' ') }\n${ err }`);
+            this.logger.error(`There was an error in the dispatch add command:\nCommand: ${ dispatchAddCommand.join(' ') }\n${ err }`);
         }
     }
 
@@ -272,8 +272,14 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
                     const culture: string = item[0];
                     const executionModelByCulture: Map<string, string> = item[1];
                     await this.executeLuisConvert(culture, executionModelByCulture);
-                    await this.executeDispatchAdd(culture, executionModelByCulture);
+                    if (!this.logger.isError) {
+                        await this.executeDispatchAdd(culture, executionModelByCulture);
+                    }
                 }));
+
+            if (this.logger.isError) {
+                throw new Error(`There were issues while converting the LU files.`);
+            }
 
             // Check if it is necessary to refresh the skill
             if (!this.configuration.noRefresh) {

--- a/tools/botskills/test/connect.test.js
+++ b/tools/botskills/test/connect.test.js
@@ -379,10 +379,7 @@ Make sure you have a Dispatch for the cultures you are trying to connect, and th
 
             strictEqual(errorList[errorList.length - 1], `There was an error while connecting the Skill to the Assistant:
 Error: An error ocurred while updating the Dispatch model:
-Error: There was an error in the bf luis:convert command:
-Command: bf luis:convert --in "${join(configuration.luisFolder, configuration.languages[0], "testSkill.lu")}" --culture ${configuration.languages[0]} --out ${join(configuration.luisFolder, configuration.languages[0], 'testskill.luis')} --name testSkill
-Error: The execution of the bf command failed with the following error:
-Error: Mocked function throws an Error`);
+Error: There were issues while converting the LU files.`);
 		});
 
         it("when the refresh execution fails", async function () {


### PR DESCRIPTION
Port 3262

### Purpose
*What is the context of this pull request? Why is it being done?*

At the moment, when botskills processes multiple languages and an error occurs while parsing LU files it will stop processing any subsequent LU file, therefore no further error will be logged.

With these changes, when there is an issue while parsing multiple languages with Ludown it will show all the error messages if there are issues with more than one, instead of showing only the first error message.

![image](https://user-images.githubusercontent.com/39467613/77690624-5c1c1f80-6f82-11ea-8fc0-a0add5350467.png)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

The exception throwing in `executeLudownParse` and `executeDispatchAdd` is changed to error loging.
After processing each language, if there was an error it will throw an exception.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
