### PR TITLE
[Virtual Assistant][Skill] Wrap with quotes the zip in the publish scripts

### DIFF
--- a/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/publish.ps1
+++ b/samples/csharp/assistants/enterprise-assistant/VirtualAssistantSample/Deployment/Scripts/publish.ps1
@@ -77,7 +77,7 @@ if($?) {
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/publish.ps1
+++ b/samples/csharp/assistants/hospitality-assistant/VirtualAssistantSample/Deployment/Scripts/publish.ps1
@@ -77,7 +77,7 @@ if($?) {
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/publish.ps1
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Scripts/publish.ps1
@@ -77,7 +77,7 @@ if($?) {
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/samples/csharp/skill/SkillSample/Deployment/Scripts/publish.ps1
+++ b/samples/csharp/skill/SkillSample/Deployment/Scripts/publish.ps1
@@ -77,7 +77,7 @@ if($?) {
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/templates/csharp/Skill/Skill/Deployment/Scripts/publish.ps1
+++ b/templates/csharp/Skill/Skill/Deployment/Scripts/publish.ps1
@@ -77,7 +77,7 @@ if($?) {
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/templates/csharp/VA/VA/Deployment/Scripts/publish.ps1
+++ b/templates/csharp/VA/VA/Deployment/Scripts/publish.ps1
@@ -77,7 +77,7 @@ if($?) {
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/deployment/scripts/publish.ps1
@@ -83,7 +83,7 @@ if($?)
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/scripts/publish.ps1
+++ b/templates/typescript/generator-bot-virtualassistant/generators/skill/templates/sample-skill/deployment/scripts/publish.ps1
@@ -83,7 +83,7 @@ if($?)
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/templates/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
+++ b/templates/typescript/samples/sample-assistant/deployment/scripts/publish.ps1
@@ -83,7 +83,7 @@ if($?)
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 

--- a/templates/typescript/samples/sample-skill/deployment/scripts/publish.ps1
+++ b/templates/typescript/samples/sample-skill/deployment/scripts/publish.ps1
@@ -83,7 +83,7 @@ if($?)
 
     # Publish zip to Azure
     Write-Host "> Publishing to Azure ..." -NoNewline
-    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src $($zipPath) --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
+    Invoke-Expression "az webapp deployment source config-zip --resource-group $($resourceGroup) --name $($name) --src '$($zipPath)' --output json" -ErrorVariable publishError -OutVariable publishOutput 2>&1 | Out-Null
     Add-Content $logFile $publishOutput | Out-Null
     Add-Content $logFile $publishError | Out-Null
 


### PR DESCRIPTION
Fix MS3581

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
All assistant and skill bots would fail to publish during the deployment process, when done so from a folder containing white spaces in its path.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We wrapped in quotes the path to the zip at the az CLI deployment line inside the `publish.ps1` of the following components:
- TypeScript Virtual Assistant Sample/Template
- TypeScript Skill Sample/Template
- C# Virtual Assistant Sample/Template
- C# Skill Sample/Template
- C# Enterprise Assistant
- C# Hospitality Assistant

![image](https://user-images.githubusercontent.com/20074735/88705628-3052a700-d0e6-11ea-922a-86e733971c20.png)

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
All tests remained passing like they did before the changes.
All bots were also tested to deploy, and generated from corresponding yeoman templates/VSIX extension, properly fixed.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
