### PR TITLE
[C#][Bot-Solutions] Add System.Obsolete in the LuisService implementation of BotSettingsBase

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -159,7 +159,6 @@ namespace Microsoft.Bot.Solutions
             /// <value>
             /// The Dispatch service for the set of cognitive models.
             /// </value>
-            [System.Obsolete]
             public LuisService DispatchModel { get; set; }
 
             /// <summary>
@@ -168,7 +167,6 @@ namespace Microsoft.Bot.Solutions
             /// <value>
             /// The collection of LUIS models.
             /// </value>
-            [System.Obsolete]
             public List<LuisService> LanguageModels { get; set; }
 
             /// <summary>

--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -6,10 +6,9 @@ namespace Microsoft.Bot.Solutions
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.Bot.Builder.AI.QnA;
     using Microsoft.Bot.Builder.Azure;
-    using Microsoft.Bot.Configuration;
     using Microsoft.Bot.Solutions.Authentication;
+    using Microsoft.Bot.Solutions.Services;
 
     /// <summary>
     /// Base class representing the configuration for a bot.
@@ -178,11 +177,8 @@ namespace Microsoft.Bot.Solutions
             /// <value>
             /// The collection of QnA Maker knowledgebases.
             /// </value>
-#pragma warning disable CS0618 // Type or member is obsolete
-
             // TODO #3139: Add required cognitive model class in Solutions SDK.
             public List<QnAMakerService> Knowledgebases { get; set; }
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public class OAuthCredentialsConfiguration

--- a/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/BotSettingsBase.cs
@@ -160,6 +160,7 @@ namespace Microsoft.Bot.Solutions
             /// <value>
             /// The Dispatch service for the set of cognitive models.
             /// </value>
+            [System.Obsolete]
             public LuisService DispatchModel { get; set; }
 
             /// <summary>
@@ -168,6 +169,7 @@ namespace Microsoft.Bot.Solutions
             /// <value>
             /// The collection of LUIS models.
             /// </value>
+            [System.Obsolete]
             public List<LuisService> LanguageModels { get; set; }
 
             /// <summary>

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Services/ConnectedService.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Services/ConnectedService.cs
@@ -52,21 +52,5 @@ namespace Microsoft.Bot.Solutions.Services
 #pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
         public JObject Properties { get; set; } = new JObject();
 #pragma warning restore CA2227 // Collection properties should be read only
-
-        /// <summary>
-        /// Decrypt properties on this service.
-        /// </summary>
-        /// <param name="secret"> secret to use to decrypt the keys in this service.</param>
-        public virtual void Decrypt(string secret)
-        {
-        }
-
-        /// <summary>
-        /// Encrypt properties on this service.
-        /// </summary>
-        /// <param name="secret">secret to use to encrypt the keys in this service.</param>
-        public virtual void Encrypt(string secret)
-        {
-        }
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Services/ConnectedService.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Services/ConnectedService.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Solutions.Services
+{
+    /// <summary>
+    /// Base configuration properties for a connected service.
+    /// </summary>
+    public class ConnectedService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectedService"/> class.
+        /// </summary>
+        /// <param name="type">The connected service type.</param>
+        public ConnectedService(string type)
+        {
+            this.Type = type;
+        }
+
+        /// <summary>
+        /// Gets or sets type of the service.
+        /// </summary>
+        /// <value>The type of service.</value>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets user friendly name of the service.
+        /// </summary>
+        /// <value>The name of the service.</value>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets unique id for the service.
+        /// </summary>
+        /// <value>The Id of the service.</value>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets properties that are not otherwise defined.
+        /// </summary>
+        /// <value>The extended properties for the object.</value>
+        /// <remarks>With this, properties not represented in the defined type are not dropped when
+        /// the JSON object is deserialized, but are instead stored in this property. Such properties
+        /// will be written to a JSON object when the instance is serialized.</remarks>
+        [JsonExtensionData(ReadData = true, WriteData = true)]
+#pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
+        public JObject Properties { get; set; } = new JObject();
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        /// <summary>
+        /// Decrypt properties on this service.
+        /// </summary>
+        /// <param name="secret"> secret to use to decrypt the keys in this service.</param>
+        public virtual void Decrypt(string secret)
+        {
+        }
+
+        /// <summary>
+        /// Encrypt properties on this service.
+        /// </summary>
+        /// <param name="secret">secret to use to encrypt the keys in this service.</param>
+        public virtual void Encrypt(string secret)
+        {
+        }
+    }
+}

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Services/LuisService.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Services/LuisService.cs
@@ -101,37 +101,5 @@ namespace Microsoft.Bot.Solutions.Services
 
             return $"https://{this.Region}.api.cognitive.microsoft.com";
         }
-
-        /// <inheritdoc/>
-        public override void Encrypt(string secret)
-        {
-            base.Encrypt(secret);
-
-            if (!string.IsNullOrEmpty(this.AuthoringKey))
-            {
-                this.AuthoringKey = this.AuthoringKey.Encrypt(secret);
-            }
-
-            if (!string.IsNullOrEmpty(this.SubscriptionKey))
-            {
-                this.SubscriptionKey = this.SubscriptionKey.Encrypt(secret);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Decrypt(string secret)
-        {
-            base.Decrypt(secret);
-
-            if (!string.IsNullOrEmpty(this.AuthoringKey))
-            {
-                this.AuthoringKey = this.AuthoringKey.Decrypt(secret);
-            }
-
-            if (!string.IsNullOrEmpty(this.SubscriptionKey))
-            {
-                this.SubscriptionKey = this.SubscriptionKey.Decrypt(secret);
-            }
-        }
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Services/LuisService.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Services/LuisService.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Configuration.Encryption;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Solutions.Services
+{
+    /// <summary>
+    /// Configuration properties for a connected LUIS Service.
+    /// </summary>
+    public class LuisService : ConnectedService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LuisService"/> class.
+        /// </summary>
+        public LuisService()
+            : base(ServiceTypes.Luis)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets appId for the LUIS model.
+        /// </summary>
+        /// <value>The App Id.</value>
+        [JsonProperty("appId")]
+        public string AppId { get; set; }
+
+        /// <summary>
+        /// Gets or sets authoringKey for interacting with service management.
+        /// </summary>
+        /// <value>The Authoring Key.</value>
+        [JsonProperty("authoringKey")]
+        public string AuthoringKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets subscriptionKey for accessing this service.
+        /// </summary>
+        /// <value>The Subscription Key.</value>
+        [JsonProperty("subscriptionKey")]
+        public string SubscriptionKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets version of the LUIS app.
+        /// </summary>
+        /// <value>The Version of the LUIS app.</value>
+        [JsonProperty("version")]
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets region.
+        /// </summary>
+        /// <value>The Region.</value>
+        [JsonProperty("region")]
+        public string Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL for a custom endpoint. This should only be used when the LUIS deployed via a container.
+        /// If a value is set, then the GetEndpoint() method will return the value for Custom Endpoint.
+        /// </summary>
+        /// <value>The Region.</value>
+        [JsonProperty("customEndpoint")]
+        public string CustomEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets the endpoint for this LUIS service.
+        /// </summary>
+        /// <returns>The URL for this service.</returns>
+        public string GetEndpoint()
+        {
+            // If a custom endpoint has been supplied, then we should return this instead of
+            // generating an endpoint based on the region.
+            if (!string.IsNullOrEmpty(this.CustomEndpoint))
+            {
+                return this.CustomEndpoint;
+            }
+
+            if (string.IsNullOrWhiteSpace(this.Region))
+            {
+                throw new System.NullReferenceException("LuisService.Region cannot be Null");
+            }
+
+#pragma warning disable CA1304 // Specify CultureInfo (this class is obsolete, we won't fix it)
+            var region = this.Region.ToLower();
+#pragma warning restore CA1304 // Specify CultureInfo
+
+            // usgovvirginia is that actual azure region name, but the cognitive service team called their endpoint 'virginia' instead of 'usgovvirginia'
+            // We handle both region names as an alias for virginia.api.cognitive.microsoft.us
+            if (region == "virginia" || region == "usgovvirginia")
+            {
+                return $"https://virginia.api.cognitive.microsoft.us";
+            }
+
+            // if it starts with usgov or usdod then it is a .us TLD
+#pragma warning disable CA1307 // Specify StringComparison (this class is obsolete, we won't fix it)
+            else if (region.StartsWith("usgov") || region.StartsWith("usdod"))
+#pragma warning restore CA1307 // Specify StringComparison
+            {
+                return $"https://{this.Region}.api.cognitive.microsoft.us";
+            }
+
+            return $"https://{this.Region}.api.cognitive.microsoft.com";
+        }
+
+        /// <inheritdoc/>
+        public override void Encrypt(string secret)
+        {
+            base.Encrypt(secret);
+
+            if (!string.IsNullOrEmpty(this.AuthoringKey))
+            {
+                this.AuthoringKey = this.AuthoringKey.Encrypt(secret);
+            }
+
+            if (!string.IsNullOrEmpty(this.SubscriptionKey))
+            {
+                this.SubscriptionKey = this.SubscriptionKey.Encrypt(secret);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Decrypt(string secret)
+        {
+            base.Decrypt(secret);
+
+            if (!string.IsNullOrEmpty(this.AuthoringKey))
+            {
+                this.AuthoringKey = this.AuthoringKey.Decrypt(secret);
+            }
+
+            if (!string.IsNullOrEmpty(this.SubscriptionKey))
+            {
+                this.SubscriptionKey = this.SubscriptionKey.Decrypt(secret);
+            }
+        }
+    }
+}

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Services/QnAMakerService.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Services/QnAMakerService.cs
@@ -49,37 +49,5 @@ namespace Microsoft.Bot.Solutions.Services
         /// <value>The endpoint.</value>
         [JsonProperty("endpointKey")]
         public string EndpointKey { get; set; }
-
-        /// <inheritdoc/>
-        public override void Encrypt(string secret)
-        {
-            base.Encrypt(secret);
-
-            if (!string.IsNullOrEmpty(this.EndpointKey))
-            {
-                this.EndpointKey = this.EndpointKey.Encrypt(secret);
-            }
-
-            if (!string.IsNullOrEmpty(this.SubscriptionKey))
-            {
-                this.SubscriptionKey = this.SubscriptionKey.Encrypt(secret);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override void Decrypt(string secret)
-        {
-            base.Decrypt(secret);
-
-            if (!string.IsNullOrEmpty(this.EndpointKey))
-            {
-                this.EndpointKey = this.EndpointKey.Decrypt(secret);
-            }
-
-            if (!string.IsNullOrEmpty(this.SubscriptionKey))
-            {
-                this.SubscriptionKey = this.SubscriptionKey.Decrypt(secret);
-            }
-        }
     }
 }

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Services/QnAMakerService.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Services/QnAMakerService.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Configuration.Encryption;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Solutions.Services
+{
+    /// <summary>
+    /// Configuration properties for a connected LUIS service.
+    /// </summary>
+    public class QnAMakerService : ConnectedService
+    {
+        private string _hostname;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QnAMakerService"/> class.
+        /// </summary>
+        public QnAMakerService()
+            : base(ServiceTypes.QnA)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets kbId.
+        /// </summary>
+        /// <value>The Knowledge Base Id.</value>
+        [JsonProperty("kbId")]
+        public string KbId { get; set; }
+
+        /// <summary>
+        /// Gets or sets subscriptionKey.
+        /// </summary>
+        /// <value>The subscription key.</value>
+        [JsonProperty("subscriptionKey")]
+        public string SubscriptionKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets url for the deployed qnaMaker instance.
+        /// </summary>
+        /// <value>The Host name.</value>
+        [JsonProperty("hostname")]
+        public string Hostname { get => _hostname; set => _hostname = new Uri(new Uri(value), "/qnamaker").AbsoluteUri; }
+
+        /// <summary>
+        /// Gets or sets endpointKey.
+        /// </summary>
+        /// <value>The endpoint.</value>
+        [JsonProperty("endpointKey")]
+        public string EndpointKey { get; set; }
+
+        /// <inheritdoc/>
+        public override void Encrypt(string secret)
+        {
+            base.Encrypt(secret);
+
+            if (!string.IsNullOrEmpty(this.EndpointKey))
+            {
+                this.EndpointKey = this.EndpointKey.Encrypt(secret);
+            }
+
+            if (!string.IsNullOrEmpty(this.SubscriptionKey))
+            {
+                this.SubscriptionKey = this.SubscriptionKey.Encrypt(secret);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Decrypt(string secret)
+        {
+            base.Decrypt(secret);
+
+            if (!string.IsNullOrEmpty(this.EndpointKey))
+            {
+                this.EndpointKey = this.EndpointKey.Decrypt(secret);
+            }
+
+            if (!string.IsNullOrEmpty(this.SubscriptionKey))
+            {
+                this.SubscriptionKey = this.SubscriptionKey.Decrypt(secret);
+            }
+        }
+    }
+}

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Services/ServiceTypes.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Services/ServiceTypes.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Bot.Solutions.Services
+{
+    /// <summary>
+    /// Constants for Azure service types.
+    /// </summary>
+    public class ServiceTypes
+    {
+        /// <summary>
+        /// Application Insights.
+        /// </summary>
+        public const string AppInsights = "appInsights";
+
+        /// <summary>
+        /// Blob Storage.
+        /// </summary>
+        public const string BlobStorage = "blob";
+
+        /// <summary>
+        /// Cosmos DB.
+        /// </summary>
+        public const string CosmosDB = "cosmosdb";
+
+        /// <summary>
+        /// Azure Bot Service.
+        /// </summary>
+        public const string Bot = "abs";
+
+        /// <summary>
+        /// Generic service.
+        /// </summary>
+        public const string Generic = "generic";
+
+        /// <summary>
+        /// Dispatch.
+        /// </summary>
+        public const string Dispatch = "dispatch";
+
+        /// <summary>
+        /// Bot Endpoint.
+        /// </summary>
+        public const string Endpoint = "endpoint";
+
+        /// <summary>
+        /// File service.
+        /// </summary>
+        public const string File = "file";
+
+        /// <summary>
+        /// LUIS Cognitive Service.
+        /// </summary>
+        public const string Luis = "luis";
+
+        /// <summary>
+        /// QnA Maker Cognitive Service.
+        /// </summary>
+        public const string QnA = "qna";
+    }
+}


### PR DESCRIPTION
Solves 3617

### Purpose
*What is the context of this pull request? Why is it being done?*
With the new [botbuilder@4.10.0-rc1](https://botbuilder.myget.org/feed/botbuilder-v4-dotnet-daily/package/nuget/Microsoft.Bot.Builder/4.10.0-rc1) packages, the LuisService class has been deprecated so Bot-Solutions doesn't build as it runs into a "LuisService is obsolete: This class is deprecated" error.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We added the `[System.Obsolete]` tag to fix the deprecation error, so that Bot-Solutions builds.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
We tested the C# solutions, after apply this fix, manually and worked as expected.

_Fix applied_
![image](https://user-images.githubusercontent.com/37625424/90182771-dbbb5700-dd88-11ea-9049-1b7b96877f0d.png)

_Successfully communication in Emulator_
![image](https://user-images.githubusercontent.com/37625424/90182840-eece2700-dd88-11ea-96f4-93e89f6fea72.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
