### PR TITLE
[Documentation] Fix ambiguities of TypeScript and C# documentation for manifests

### DIFF
--- a/docs/_docs/skills/tutorials/create-skill/csharp/5-update-manifest.md
+++ b/docs/_docs/skills/tutorials/create-skill/csharp/5-update-manifest.md
@@ -17,4 +17,9 @@ A default manifest describing your Skill is provided as part of the project, you
 
 1. Update `{YOUR_SKILL_APPID}` with the Active Directory AppID of your deployed Skill, you can find this within your `appSettings.json` file.
 
-1. Publish the changes to your Skill endpoint and validate that you can retrieve the manifest using the browser (`/manifest/manifest-1.1.json`)
+1. Publish the changes to your Skill endpoint and validate that you can retrieve the manifest using the browser (`/manifest/manifest-1.1.json`). Check the [deployment scripts](https://microsoft.github.io/botframework-solutions/virtual-assistant/handbook/deployment-scripts/) document.
+```powershell 
+.\Deployment\Scripts\publish.ps1 -botWebAppName {YOUR_SKILL_BOTWEBAPP_NAME} -resourceGroup {YOUR_RESOURCEGROUP_NAME}
+```
+
+> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppIp` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.

--- a/docs/_docs/skills/tutorials/create-skill/csharp/5-update-manifest.md
+++ b/docs/_docs/skills/tutorials/create-skill/csharp/5-update-manifest.md
@@ -22,4 +22,4 @@ A default manifest describing your Skill is provided as part of the project, you
 .\Deployment\Scripts\publish.ps1 -botWebAppName {YOUR_SKILL_BOTWEBAPP_NAME} -resourceGroup {YOUR_RESOURCEGROUP_NAME}
 ```
 
-> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppIp` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.
+> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppId` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.

--- a/docs/_docs/skills/tutorials/create-skill/csharp/5-update-manifest.md
+++ b/docs/_docs/skills/tutorials/create-skill/csharp/5-update-manifest.md
@@ -22,4 +22,4 @@ A default manifest describing your Skill is provided as part of the project, you
 .\Deployment\Scripts\publish.ps1 -botWebAppName {YOUR_SKILL_BOTWEBAPP_NAME} -resourceGroup {YOUR_RESOURCEGROUP_NAME}
 ```
 
-> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppId` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.
+> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages that matches with the "Messaging endpoint" of the Web App Bot resource after deployment (e.g. `https://bf-skill.azurewebsites.net/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppId` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.

--- a/docs/_docs/skills/tutorials/create-skill/typescript/5-update-manifest.md
+++ b/docs/_docs/skills/tutorials/create-skill/typescript/5-update-manifest.md
@@ -22,4 +22,4 @@ A default manifest describing your Skill is provided as part of the project, you
 .\Deployment\Scripts\publish.ps1 -botWebAppName {YOUR_SKILL_BOTWEBAPP_NAME} -resourceGroup {YOUR_RESOURCEGROUP_NAME}
 ```
 
-> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppIp` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.
+> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppId` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.

--- a/docs/_docs/skills/tutorials/create-skill/typescript/5-update-manifest.md
+++ b/docs/_docs/skills/tutorials/create-skill/typescript/5-update-manifest.md
@@ -22,4 +22,4 @@ A default manifest describing your Skill is provided as part of the project, you
 .\Deployment\Scripts\publish.ps1 -botWebAppName {YOUR_SKILL_BOTWEBAPP_NAME} -resourceGroup {YOUR_RESOURCEGROUP_NAME}
 ```
 
-> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppId` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.
+> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages that matches with the "Messaging endpoint" of the Web App Bot resource after deployment (e.g. `https://bf-skill.azurewebsites.net/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppId` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.

--- a/docs/_docs/skills/tutorials/create-skill/typescript/5-update-manifest.md
+++ b/docs/_docs/skills/tutorials/create-skill/typescript/5-update-manifest.md
@@ -11,10 +11,15 @@ order: 5
 
 ## {{ page.title }}
 
-A default manifest describing your Skill is provided as part of the project, you can find this within the `wwwroot\src\manifest` folder. Following deployment this requires updating with the deployment URL and Azure AD Application ID. `manifest-1.0` is provided for Power Virtual Agent support only, you should use `manifest-1.1` for Virtual Assistant scenarios.
+A default manifest describing your Skill is provided as part of the project, you can find this within the `src\manifest` folder. Following deployment this requires updating with the deployment URL and Azure AD Application ID. `manifest-1.0` is provided for Power Virtual Agent support only, you should use `manifest-1.1` for Virtual Assistant scenarios.
 
 1. Update `{YOUR_SKILL_URL}` with the URL of your deployed Skill endpoint, this must be prefixed with https.
 
 1. Update `{YOUR_SKILL_APPID}` with the Active Directory AppID of your deployed Skill, you can find this within your `appSettings.json` file.
 
-1. Publish the changes to your Skill endpoint and validate that you can retrieve the manifest using the browser (`/manifest/manifest-1.1.json`)
+1. Publish the changes to your Skill endpoint and validate that you can retrieve the manifest using the browser (`/manifest/manifest-1.1.json`). Check the [deployment scripts](https://microsoft.github.io/botframework-solutions/virtual-assistant/handbook/deployment-scripts/) document.
+```powershell 
+.\Deployment\Scripts\publish.ps1 -botWebAppName {YOUR_SKILL_BOTWEBAPP_NAME} -resourceGroup {YOUR_RESOURCEGROUP_NAME}
+```
+
+> **Note**: `{YOUR_SKILL_URL}` is the endpoint URL where the Skill will receive the messages (e.g. `http://localhost:3979/api/messages`). Also, `{YOUR_SKILL_APPID}` is the `microsoftAppIp` value, the `{YOUR_SKILL_BOTWEBAPP_NAME}` is the `botWebAppName` and the `{YOUR_RESOURCEGROUP_NAME}` is the `resourceGroupName` that you can find in the `appsettings.json` file populated after the deployment of the Skill.

--- a/docs/_docs/skills/tutorials/create-skill/typescript/6-run-your-skill.md
+++ b/docs/_docs/skills/tutorials/create-skill/typescript/6-run-your-skill.md
@@ -20,7 +20,7 @@ After deployment, you can run and test your Skill project using these steps:
 
     ![]({{site.baseurl}}/assets/images/quickstart-virtualassistant-openbot.png)
 
-1. Provide the messaging endpoint of your running bot (e.g: http://localhost:3978/api/messages).
+1. Provide the messaging endpoint of your running bot (e.g: http://localhost:3980/api/messages).
 1. Provide the Microsoft App ID and Microsoft App Password values from your **appsettings.json** file.
 
     ![]({{site.baseurl}}/assets/images/quickstart-virtualassistant-openbotmodal.png)

--- a/docs/_docs/skills/tutorials/create-skill/typescript/7-add-your-skill.md
+++ b/docs/_docs/skills/tutorials/create-skill/typescript/7-add-your-skill.md
@@ -13,7 +13,7 @@ order: 7
 
 ## Validate the Skill manifest endpoint
 
-To validate your Skill is deployed and working open up a browser window and navigate to your deployed Skill manifest. e.g.  `http://localhost:3978/manifest/manifest-1.1.json`
+To validate your Skill is deployed and working open up a browser window and navigate to your deployed Skill manifest. e.g.  `http://localhost:3980/manifest/manifest-1.1.json`
 
 ## Adding your skill to an assistant
 

--- a/docs/_docs/skills/tutorials/create-skill/typescript/7-add-your-skill.md
+++ b/docs/_docs/skills/tutorials/create-skill/typescript/7-add-your-skill.md
@@ -13,7 +13,7 @@ order: 7
 
 ## Validate the Skill manifest endpoint
 
-To validate your Skill is deployed and working open up a browser window and navigate to your deployed Skill manifest. e.g.  `http://localhost:3978/src/manifest/manifest-1.1.json`
+To validate your Skill is deployed and working open up a browser window and navigate to your deployed Skill manifest. e.g.  `http://localhost:3978/manifest/manifest-1.1.json`
 
 ## Adding your skill to an assistant
 

--- a/docs/_docs/virtual-assistant/tutorials/create-assistant/typescript/5-run-your-assistant.md
+++ b/docs/_docs/virtual-assistant/tutorials/create-assistant/typescript/5-run-your-assistant.md
@@ -20,7 +20,7 @@ After deployment, you can run and test your Virtual Assistant project using thes
 
     ![]({{site.baseurl}}/assets/images/quickstart-virtualassistant-openbot.png)
 
-1. Provide the messaging endpoint of your running bot (e.g: http://localhost:3978/api/messages).
+1. Provide the messaging endpoint of your running bot (e.g: http://localhost:3979/api/messages).
 1. Provide the Microsoft App ID and Microsoft App Password values from your **appsettings.json** file.
 
     ![]({{site.baseurl}}/assets/images/quickstart-virtualassistant-openbotmodal.png)


### PR DESCRIPTION
Fix 3638

### Purpose
*What is the context of this pull request? Why is it being done?*
The documentation [TypeScript Update your Skill Manifest](https://microsoft.github.io/botframework-solutions/skills/tutorials/create-skill/typescript/5-update-manifest/), [C# Update your Skill Manifest](https://microsoft.github.io/botframework-solutions/skills/tutorials/create-skill/csharp/5-update-manifest/) and [TypeScript Add your skill to a Virtual Assistant](https://microsoft.github.io/botframework-solutions/skills/tutorials/create-skill/typescript/5-update-manifest/) presents ambiguities described in the issue 3638.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Explain the values of some placeholders
- Add a `publish.ps1` example
- Link to deployment scripts document
- Fix inconsistences of TypeScript manifests

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [X] I have updated related documentation
