### PR TITLE
[TypeScript][Virtual Assistant] Migration to TypeScript 4

### DIFF
--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/_.eslintrc.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/_.eslintrc.json
@@ -25,9 +25,7 @@
         "@typescript-eslint/indent": ["error", 4],
         "@typescript-eslint/interface-name-prefix": 0,
         "@typescript-eslint/no-explicit-any": 0,
-        "@typescript-eslint/no-object-literal-type-assertion": ["error", {
-            "allowAsParameter": true
-         }],
+        "@typescript-eslint/consistent-type-assertions": ["error", { "assertionStyle": "as" }],
         "@typescript-eslint/no-use-before-define": ["error", { "functions": false, "classes": true }],
         "@typescript-eslint/ban-types": 0
     }

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/_package.json
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/_package.json
@@ -34,10 +34,10 @@
     },
     "devDependencies": {
         "@types/restify": "^8.4.2",
-        "@typescript-eslint/eslint-plugin": "^2.0.0",
-        "@typescript-eslint/parser": "^2.0.0",
+        "@typescript-eslint/eslint-plugin": "^4.0.1",
+        "@typescript-eslint/parser": "^4.0.1",
         "copyfiles": "^2.1.0",
-        "eslint": "^5.16.0",
+        "eslint": "^6.1.0",
         "eslint-plugin-only-warn": "^1.0.1",
         "mocha": "^6.1.4",
         "mocha-junit-reporter": "^1.22.0",
@@ -45,7 +45,7 @@
         "nodemon": "^2.0.2",
         "nyc": "^14.1.1",
         "rimraf": "^2.6.2",
-        "typescript": "^3.2.2"
+        "typescript": "^4.0.5"
     },
     "env": {
         "mocha": true,

--- a/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/onboardingDialog.ts
+++ b/templates/typescript/generator-bot-virtualassistant/generators/app/templates/sample-assistant/src/dialogs/onboardingDialog.ts
@@ -13,7 +13,7 @@ import {
 import { IUserProfileState } from '../models/userProfileState';
 import { StateProperties } from '../models/stateProperties';
 import { BotServices } from '../services/botServices';
-import { LocaleTemplateManager, DialogContextEx } from 'bot-solutions';
+import { LocaleTemplateManager } from 'bot-solutions';
 import { LuisRecognizer } from 'botbuilder-ai';
 
 enum DialogIds {
@@ -53,7 +53,7 @@ export class OnboardingDialog extends ComponentDialog {
         }
         
         return await sc.prompt(DialogIds.NamePrompt, {
-                prompt: this.templateManager.generateActivityForLocale('NamePrompt', sc.context.activity.locale),
+            prompt: this.templateManager.generateActivityForLocale('NamePrompt', sc.context.activity.locale),
         });
     }
 

--- a/templates/typescript/samples/sample-assistant/.eslintrc.json
+++ b/templates/typescript/samples/sample-assistant/.eslintrc.json
@@ -25,9 +25,7 @@
         "@typescript-eslint/indent": ["error", 4],
         "@typescript-eslint/interface-name-prefix": 0,
         "@typescript-eslint/no-explicit-any": 0,
-        "@typescript-eslint/no-object-literal-type-assertion": ["error", {
-            "allowAsParameter": true
-         }],
+        "@typescript-eslint/consistent-type-assertions": ["error", { "assertionStyle": "as" }],
         "@typescript-eslint/no-use-before-define": ["error", { "functions": false, "classes": true }],
         "@typescript-eslint/ban-types": 0
     }

--- a/templates/typescript/samples/sample-assistant/package-lock.json
+++ b/templates/typescript/samples/sample-assistant/package-lock.json
@@ -147,14 +147,6 @@
             "integrity": "sha1-hxgH8QRCuS/5fkeDubVPagyoEtA=",
             "dev": true
         },
-        "@babel/runtime": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/runtime/-/@babel/runtime-7.10.2.tgz",
-            "integrity": "sha1-0QPyHyYCSX04NIoy4AhjfVBtuDk=",
-            "requires": {
-                "regenerator-runtime": "^0.13.4"
-            }
-        },
         "@babel/template": {
             "version": "7.10.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.10.1.tgz",
@@ -364,6 +356,32 @@
                 }
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@nodelib/fs.scandir/-/@nodelib/fs.scandir-2.1.3.tgz",
+            "integrity": "sha1-Olgr21OATGum0UZXnEblITDPSjs=",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@nodelib/fs.stat/-/@nodelib/fs.stat-2.0.3.tgz",
+            "integrity": "sha1-NNxfTKu8cg9OYPdadH5+zWwXW9M=",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@nodelib/fs.walk/-/@nodelib/fs.walk-1.2.4.tgz",
+            "integrity": "sha1-ARuSAqcKY2bkNspcBlhEUoqwSXY=",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
         "@sindresorhus/is": {
             "version": "0.14.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@sindresorhus/is/-/@sindresorhus/is-0.14.0.tgz",
@@ -429,12 +447,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/eslint-visitor-keys": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/eslint-visitor-keys/-/@types/eslint-visitor-keys-1.0.0.tgz",
-            "integrity": "sha1-HuMNeVRMqE1o1LPNsK9PIFZj3S0=",
-            "dev": true
-        },
         "@types/events": {
             "version": "3.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/events/-/@types/events-3.0.0.tgz",
@@ -442,9 +454,9 @@
             "dev": true
         },
         "@types/express": {
-            "version": "4.17.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.17.6.tgz",
-            "integrity": "sha1-a85J5JVwUHuG6hsHuAbwRpf6xF4=",
+            "version": "4.17.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express/-/@types/express-4.17.9.tgz",
+            "integrity": "sha1-9fLfat1wP/KEKK3VK97IoQkbCng=",
             "requires": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "*",
@@ -462,9 +474,9 @@
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.17.7",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.17.7.tgz",
-            "integrity": "sha1-3+Yfhw61SdxtfhIFCQGEfH1+kVs=",
+            "version": "4.17.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/express-serve-static-core/-/@types/express-serve-static-core-4.17.13.tgz",
+            "integrity": "sha1-2a8CXpJfyLCJvjdCO40erHgb4IQ=",
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -489,25 +501,10 @@
                 "@types/node": "*"
             }
         },
-        "@types/i18next": {
-            "version": "2.3.41",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next/-/@types/i18next-2.3.41.tgz",
-            "integrity": "sha1-Wj69y0lCBSyi73HE9jQUOMV8sYw=",
-            "dev": true
-        },
-        "@types/i18next-node-fs-backend": {
-            "version": "0.0.30",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/i18next-node-fs-backend/-/@types/i18next-node-fs-backend-0.0.30.tgz",
-            "integrity": "sha1-dFT46SN5ii6/FjCb78/f3jLpCnw=",
-            "dev": true,
-            "requires": {
-                "@types/i18next": "^2"
-            }
-        },
         "@types/json-schema": {
-            "version": "7.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/json-schema/-/@types/json-schema-7.0.4.tgz",
-            "integrity": "sha1-OP1z3f2bVaux4bLtV4y1W9e30zk=",
+            "version": "7.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/json-schema/-/@types/json-schema-7.0.6.tgz",
+            "integrity": "sha1-9MfsQ+gbMZqYFRFQMXCfJph4kfA=",
             "dev": true
         },
         "@types/jsonwebtoken": {
@@ -524,9 +521,9 @@
             "integrity": "sha1-V/Io8rgMBGtKG9XKwDH4HyB/TwM="
         },
         "@types/mime": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-2.0.2.tgz",
-            "integrity": "sha1-hXoRjYY0yEu6euFAiORQhJDNXaU="
+            "version": "2.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/mime/-/@types/mime-2.0.3.tgz",
+            "integrity": "sha1-yJO3NyHbc2mZQ7/DZTsd63+qSjo="
         },
         "@types/moment-timezone": {
             "version": "0.5.13",
@@ -542,9 +539,9 @@
             "integrity": "sha1-Q4lquH/IK9od/WAM30SgyKZOEdI="
         },
         "@types/qs": {
-            "version": "6.9.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/qs/-/@types/qs-6.9.3.tgz",
-            "integrity": "sha1-t1Wgk0VkogDT79+IVG7JPDaavQM="
+            "version": "6.9.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/qs/-/@types/qs-6.9.5.tgz",
+            "integrity": "sha1-Q0cRvdSete5p2QwdZ8NUqajssYs="
         },
         "@types/range-parser": {
             "version": "1.2.3",
@@ -564,12 +561,12 @@
             }
         },
         "@types/serve-static": {
-            "version": "1.13.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.4.tgz",
-            "integrity": "sha1-ZmKpNYPlpsq8obI1kuuR4S+oDnw=",
+            "version": "1.13.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/serve-static/-/@types/serve-static-1.13.8.tgz",
+            "integrity": "sha1-hREp1DRDPHCCFIV0/+wmPVgwnEY=",
             "requires": {
-                "@types/express-serve-static-core": "*",
-                "@types/mime": "*"
+                "@types/mime": "*",
+                "@types/node": "*"
             }
         },
         "@types/spdy": {
@@ -603,77 +600,27 @@
             "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E="
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "2.34.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/eslint-plugin/-/@typescript-eslint/eslint-plugin-2.34.0.tgz",
-            "integrity": "sha1-b4zopGx96kpvHRcdK7j7rm2sK+k=",
+            "version": "4.8.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/eslint-plugin/-/@typescript-eslint/eslint-plugin-4.8.1.tgz",
+            "integrity": "sha1-s2Kr4O5HimxtBsFFUqZJfwtIB2k=",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "2.34.0",
+                "@typescript-eslint/experimental-utils": "4.8.1",
+                "@typescript-eslint/scope-manager": "4.8.1",
+                "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
                 "regexpp": "^3.0.0",
-                "tsutils": "^3.17.1"
-            }
-        },
-        "@typescript-eslint/experimental-utils": {
-            "version": "2.34.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/experimental-utils/-/@typescript-eslint/experimental-utils-2.34.0.tgz",
-            "integrity": "sha1-01JLZEzbQO687KZ/jPPkzJyPmA8=",
-            "dev": true,
-            "requires": {
-                "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/typescript-estree": "2.34.0",
-                "eslint-scope": "^5.0.0",
-                "eslint-utils": "^2.0.0"
-            }
-        },
-        "@typescript-eslint/parser": {
-            "version": "2.34.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/parser/-/@typescript-eslint/parser-2.34.0.tgz",
-            "integrity": "sha1-UCUmMMoxloVCDpo5ygX+GFola8g=",
-            "dev": true,
-            "requires": {
-                "@types/eslint-visitor-keys": "^1.0.0",
-                "@typescript-eslint/experimental-utils": "2.34.0",
-                "@typescript-eslint/typescript-estree": "2.34.0",
-                "eslint-visitor-keys": "^1.1.0"
-            }
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "2.34.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/typescript-estree/-/@typescript-eslint/typescript-estree-2.34.0.tgz",
-            "integrity": "sha1-FK62NTs57wcyzH8bgoUpSTfPN9U=",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.1",
-                "eslint-visitor-keys": "^1.1.0",
-                "glob": "^7.1.6",
-                "is-glob": "^4.0.1",
-                "lodash": "^4.17.15",
                 "semver": "^7.3.2",
                 "tsutils": "^3.17.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -690,6 +637,114 @@
                 }
             }
         },
+        "@typescript-eslint/experimental-utils": {
+            "version": "4.8.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/experimental-utils/-/@typescript-eslint/experimental-utils-4.8.1.tgz",
+            "integrity": "sha1-JydcIPpDNt+Z689hlffXqnqp8i0=",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/scope-manager": "4.8.1",
+                "@typescript-eslint/types": "4.8.1",
+                "@typescript-eslint/typescript-estree": "4.8.1",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
+            }
+        },
+        "@typescript-eslint/parser": {
+            "version": "4.8.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/parser/-/@typescript-eslint/parser-4.8.1.tgz",
+            "integrity": "sha1-T+L727Z0hbr8QyCzrpHjTv4SGdE=",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/scope-manager": "4.8.1",
+                "@typescript-eslint/types": "4.8.1",
+                "@typescript-eslint/typescript-estree": "4.8.1",
+                "debug": "^4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/scope-manager": {
+            "version": "4.8.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/scope-manager/-/@typescript-eslint/scope-manager-4.8.1.tgz",
+            "integrity": "sha1-40PEdfjx0VgBtUbLF9fzCbdo/c4=",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.8.1",
+                "@typescript-eslint/visitor-keys": "4.8.1"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "4.8.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/types/-/@typescript-eslint/types-4.8.1.tgz",
+            "integrity": "sha1-I4Kcc8X8b0/NU0aneAsnT3L+4iI=",
+            "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "4.8.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/typescript-estree/-/@typescript-eslint/typescript-estree-4.8.1.tgz",
+            "integrity": "sha1-cwfj8snpXffaqNwKNLjEO37A3TI=",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.8.1",
+                "@typescript-eslint/visitor-keys": "4.8.1",
+                "debug": "^4.1.1",
+                "globby": "^11.0.1",
+                "is-glob": "^4.0.1",
+                "lodash": "^4.17.15",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "4.8.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@typescript-eslint/visitor-keys/-/@typescript-eslint/visitor-keys-4.8.1.tgz",
+            "integrity": "sha1-eU9o7iktGy46qWkOvt/LOoyQ48M=",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.8.1",
+                "eslint-visitor-keys": "^2.0.0"
+            }
+        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/abbrev/-/abbrev-1.1.1.tgz",
@@ -697,15 +752,15 @@
             "dev": true
         },
         "acorn": {
-            "version": "6.4.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn/-/acorn-6.4.1.tgz",
-            "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=",
+            "version": "7.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
             "dev": true
         },
         "acorn-jsx": {
-            "version": "5.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-            "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4=",
+            "version": "5.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=",
             "dev": true
         },
         "adal-node": {
@@ -823,10 +878,21 @@
             "dev": true
         },
         "ansi-escapes": {
-            "version": "3.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-            "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
-            "dev": true
+            "version": "4.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+            "integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
+            "dev": true,
+            "requires": {
+                "type-fest": "^0.11.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=",
+                    "dev": true
+                }
+            }
         },
         "ansi-regex": {
             "version": "5.0.0",
@@ -889,9 +955,16 @@
             "version": "1.0.10",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
+        },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
+            "dev": true
         },
         "asn1": {
             "version": "0.2.4",
@@ -1072,8 +1145,8 @@
         },
         "bot-solutions": {
             "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bot-solutions/-/bot-solutions-1.0.0.tgz",
-            "integrity": "sha1-P1LISJL7sl+v6xbSqkiZmDER0tI=",
+            "resolved": false,
+            "integrity": "sha512-+5QFNhE0VPpVoI/LP2fO6MnwoSWmJsWY3d1CIRfdy8A4XbcNcBHD3VTWgodvXD4672O1z0l66bfu2HoUMDZQMA==",
             "requires": {
                 "@azure/cognitiveservices-luis-authoring": "^2.1.0",
                 "@microsoft/recognizers-text": "^1.1.4",
@@ -1081,19 +1154,17 @@
                 "@types/lru-cache": "^5.1.0",
                 "adaptivecards": "^1.1.3",
                 "azure-cognitiveservices-contentmoderator": "^4.0.0",
-                "botbuilder": "^4.9.0",
-                "botbuilder-ai": "^4.9.0",
-                "botbuilder-azure": "^4.9.0",
-                "botbuilder-dialogs": "^4.9.0",
-                "botbuilder-lg": "^4.9.0",
-                "botframework-config": "^4.9.0",
-                "botframework-connector": "^4.9.0",
+                "botbuilder": "^4.9.2",
+                "botbuilder-ai": "^4.9.2",
+                "botbuilder-azure": "^4.9.2",
+                "botbuilder-dialogs": "^4.9.2",
+                "botbuilder-lg": "^4.9.2",
+                "botframework-config": "^4.9.2",
+                "botframework-connector": "^4.9.2",
                 "dayjs": "1.8.17",
-                "i18next": "^15.0.6",
-                "i18next-node-fs-backend": "^2.1.1",
                 "jwks-rsa": "1.5.0",
                 "ms-rest-azure": "^2.5.0",
-                "p-queue": "^4.0.0",
+                "p-queue": "^6.0.0",
                 "request-promise-native": "^1.0.7",
                 "uuid": "^3.3.2",
                 "xml-js": "^1.6.11"
@@ -1638,18 +1709,18 @@
             "dev": true
         },
         "cli-cursor": {
-            "version": "2.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
-            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "^3.1.0"
             }
         },
         "cli-width": {
-            "version": "2.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-width/-/cli-width-2.2.1.tgz",
-            "integrity": "sha1-sEM9C06chH7xiGik7xb9X8gnHEg=",
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha1-ovSEN6LKqaIkNueUvwceyeYc7fY=",
             "dev": true
         },
         "cliui": {
@@ -2011,6 +2082,23 @@
             "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
             "dev": true
         },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
+                    "dev": true
+                }
+            }
+        },
         "doctrine": {
             "version": "3.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/doctrine/-/doctrine-3.0.0.tgz",
@@ -2070,9 +2158,9 @@
             }
         },
         "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+            "version": "0.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY="
         },
         "duplexer3": {
             "version": "0.1.4",
@@ -2209,72 +2297,63 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
-            "version": "5.16.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint/-/eslint-5.16.0.tgz",
-            "integrity": "sha1-oeOsGq5KP72Clvz496tzFMu2q+o=",
+            "version": "6.8.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint/-/eslint-6.8.0.tgz",
+            "integrity": "sha1-YiYtZylzn5J1cjgkMC+yJ8jJP/s=",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "ajv": "^6.9.1",
+                "ajv": "^6.10.0",
                 "chalk": "^2.1.0",
                 "cross-spawn": "^6.0.5",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
-                "eslint-scope": "^4.0.3",
-                "eslint-utils": "^1.3.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^5.0.1",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^1.4.3",
+                "eslint-visitor-keys": "^1.1.0",
+                "espree": "^6.1.2",
                 "esquery": "^1.0.1",
                 "esutils": "^2.0.2",
                 "file-entry-cache": "^5.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.7.0",
+                "glob-parent": "^5.0.0",
+                "globals": "^12.1.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
-                "inquirer": "^6.2.2",
-                "js-yaml": "^3.13.0",
+                "inquirer": "^7.0.0",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.3.0",
-                "lodash": "^4.17.11",
+                "lodash": "^4.17.14",
                 "minimatch": "^3.0.4",
                 "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
+                "optionator": "^0.8.3",
                 "progress": "^2.0.0",
                 "regexpp": "^2.0.1",
-                "semver": "^5.5.1",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "^2.0.1",
+                "semver": "^6.1.2",
+                "strip-ansi": "^5.2.0",
+                "strip-json-comments": "^3.0.1",
                 "table": "^5.2.3",
-                "text-table": "^0.2.0"
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
                     "dev": true
                 },
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "eslint-scope": {
-                    "version": "4.0.3",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
-                    "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.1.0",
-                        "estraverse": "^4.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "eslint-utils": {
@@ -2286,19 +2365,26 @@
                         "eslint-visitor-keys": "^1.1.0"
                     }
                 },
-                "glob": {
-                    "version": "7.1.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/glob/-/glob-7.1.6.tgz",
-                    "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "type-fest": "^0.8.1"
                     }
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.2",
@@ -2312,14 +2398,26 @@
                     "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
                     "dev": true
                 },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+                    "dev": true
+                },
                 "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
+                },
+                "strip-json-comments": {
+                    "version": "3.1.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+                    "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+                    "dev": true
                 }
             }
         },
@@ -2330,45 +2428,62 @@
             "dev": true
         },
         "eslint-scope": {
-            "version": "5.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
-            "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+            "version": "5.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
+                "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
             }
         },
         "eslint-utils": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-utils/-/eslint-utils-2.0.0.tgz",
-            "integrity": "sha1-e+HMcPJ6cqds0UqmmLyr7WiQ4c0=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
+                    "dev": true
+                }
             }
         },
         "eslint-visitor-keys": {
-            "version": "1.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-            "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+            "integrity": "sha1-If3I+82ceVzAMh8FY3AglXUVEag=",
             "dev": true
         },
         "espree": {
-            "version": "5.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/espree/-/espree-5.0.1.tgz",
-            "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
+            "version": "6.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/espree/-/espree-6.2.1.tgz",
+            "integrity": "sha1-d/xy4f10SiBSwg84pbV1gy6Cc0o=",
             "dev": true,
             "requires": {
-                "acorn": "^6.0.7",
-                "acorn-jsx": "^5.0.0",
-                "eslint-visitor-keys": "^1.0.0"
+                "acorn": "^7.1.1",
+                "acorn-jsx": "^5.2.0",
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
+                    "dev": true
+                }
             }
         },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+            "dev": true
         },
         "esquery": {
             "version": "1.3.1",
@@ -2380,20 +2495,28 @@
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.1.0.tgz",
-                    "integrity": "sha1-N0MJ05/ZNa5QDnuS6Ka0xyDllkI=",
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
                     "dev": true
                 }
             }
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+                    "dev": true
+                }
             }
         },
         "estraverse": {
@@ -2414,9 +2537,9 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "eventemitter3": {
-            "version": "3.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
-            "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc="
+            "version": "4.0.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8="
         },
         "ewma": {
             "version": "2.0.1",
@@ -2471,6 +2594,20 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
             "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ="
         },
+        "fast-glob": {
+            "version": "3.2.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-glob/-/fast-glob-3.2.4.tgz",
+            "integrity": "sha1-0grvv5lXk4Pn88xmUpFYybmFVNM=",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2482,10 +2619,19 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "fastq": {
+            "version": "1.9.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fastq/-/fastq-1.9.0.tgz",
+            "integrity": "sha1-4Wpy8zjqykjpG1wjWTvMLvZreUc=",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
+        },
         "figures": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/figures/-/figures-2.0.0.tgz",
-            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "version": "3.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5"
@@ -2803,6 +2949,20 @@
             "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
             "dev": true
         },
+        "globby": {
+            "version": "11.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha1-mivxB6Bo8//qvEmtcCx57ejP01c=",
+            "dev": true,
+            "requires": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            }
+        },
         "got": {
             "version": "9.6.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/got/-/got-9.6.0.tgz",
@@ -2988,23 +3148,6 @@
                 "sshpk": "^1.7.0"
             }
         },
-        "i18next": {
-            "version": "15.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next/-/i18next-15.1.3.tgz",
-            "integrity": "sha1-8ZhMvuDjywDP+QCLA3JkKJzohAo=",
-            "requires": {
-                "@babel/runtime": "^7.3.1"
-            }
-        },
-        "i18next-node-fs-backend": {
-            "version": "2.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next-node-fs-backend/-/i18next-node-fs-backend-2.1.3.tgz",
-            "integrity": "sha1-SD+p7aTBUtYqOlW8ripXJ7qIdVk=",
-            "requires": {
-                "js-yaml": "3.13.1",
-                "json5": "2.0.0"
-            }
-        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3014,9 +3157,9 @@
             }
         },
         "ignore": {
-            "version": "4.0.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore/-/ignore-4.0.6.tgz",
-            "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+            "version": "5.1.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc=",
             "dev": true
         },
         "ignore-by-default": {
@@ -3026,9 +3169,9 @@
             "dev": true
         },
         "import-fresh": {
-            "version": "3.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-fresh/-/import-fresh-3.2.1.tgz",
-            "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+            "version": "3.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/import-fresh/-/import-fresh-3.2.2.tgz",
+            "integrity": "sha1-/BKcFgxdaCNVB/QzGmuq0Ya9vD4=",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -3068,74 +3211,55 @@
             "dev": true
         },
         "inquirer": {
-            "version": "6.5.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inquirer/-/inquirer-6.5.2.tgz",
-            "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
+            "version": "7.3.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/inquirer/-/inquirer-7.3.3.tgz",
+            "integrity": "sha1-BNF2sq8Er8FXqD/XwQDpjuCq0AM=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.2.0",
-                "chalk": "^2.4.2",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
                 "external-editor": "^3.0.3",
-                "figures": "^2.0.0",
-                "lodash": "^4.17.12",
-                "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^6.4.0",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^5.1.0",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.19",
+                "mute-stream": "0.0.8",
+                "run-async": "^2.4.0",
+                "rxjs": "^6.6.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
                 "through": "^2.3.6"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^3.0.0"
-                            }
-                        }
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.20",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "4.1.0",
-                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-                            "dev": true
-                        }
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -3440,6 +3564,7 @@
             "version": "3.13.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
             "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -3501,14 +3626,6 @@
             "version": "5.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "json5": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-2.0.0.tgz",
-            "integrity": "sha1-thq/l6oXjEtYU6ZsyO7K/QMEXXg=",
-            "requires": {
-                "minimist": "^1.2.0"
-            }
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -3855,6 +3972,22 @@
                 }
             }
         },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "4.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/micromatch/-/micromatch-4.0.2.tgz",
+            "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+            }
+        },
         "mime": {
             "version": "2.4.6",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mime/-/mime-2.4.6.tgz",
@@ -3874,9 +4007,9 @@
             }
         },
         "mimic-fn": {
-            "version": "1.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
             "dev": true
         },
         "mimic-response": {
@@ -4235,9 +4368,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.61",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.61.tgz",
-                    "integrity": "sha1-0pkTbOVLyvGrqkpIf55L7faw05M="
+                    "version": "8.10.66",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.66.tgz",
+                    "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
                 },
                 "adal-node": {
                     "version": "0.1.28",
@@ -4266,9 +4399,9 @@
             }
         },
         "mute-stream": {
-            "version": "0.0.7",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "version": "0.0.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
             "dev": true
         },
         "mv": {
@@ -4778,12 +4911,12 @@
             }
         },
         "onetime": {
-            "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/onetime/-/onetime-2.0.1.tgz",
-            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "version": "5.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "^2.1.0"
             }
         },
         "optionator": {
@@ -4851,11 +4984,20 @@
             }
         },
         "p-queue": {
-            "version": "4.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-queue/-/p-queue-4.0.0.tgz",
-            "integrity": "sha1-7Q7uh5iSftbywvX1t3/bIGGl00Y=",
+            "version": "6.6.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-queue/-/p-queue-6.6.2.tgz",
+            "integrity": "sha1-IGip3PjmfdDsPnory3aBD6qF5CY=",
             "requires": {
-                "eventemitter3": "^3.1.0"
+                "eventemitter3": "^4.0.4",
+                "p-timeout": "^3.2.0"
+            }
+        },
+        "p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+            "requires": {
+                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -4934,12 +5076,6 @@
             "version": "1.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-            "dev": true
         },
         "path-key": {
             "version": "2.0.1",
@@ -5245,11 +5381,6 @@
                 "picomatch": "^2.2.1"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.13.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-            "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc="
-        },
         "regexp.prototype.flags": {
             "version": "1.3.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
@@ -5333,19 +5464,26 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.3.tgz",
-            "integrity": "sha1-6aPAgbUTgN/qZ3M2Bh/qh5qCnuk=",
+            "version": "1.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
             "requires": {
-                "lodash": "^4.17.15"
+                "lodash": "^4.17.19"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.20",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
+                }
             }
         },
         "request-promise-native": {
-            "version": "1.0.8",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.8.tgz",
-            "integrity": "sha1-pFW5YLgm5E4r+Jma9k3/K/5YyzY=",
+            "version": "1.0.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha1-5AcSBSal79yaObKKVnm/R7nZ3Cg=",
             "requires": {
-                "request-promise-core": "1.1.3",
+                "request-promise-core": "1.1.4",
                 "stealthy-require": "^1.1.1",
                 "tough-cookie": "^2.3.3"
             }
@@ -5444,12 +5582,12 @@
             }
         },
         "restore-cursor": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
-            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "version": "3.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
+                "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2"
             }
         },
@@ -5457,6 +5595,12 @@
             "version": "0.2.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ret/-/ret-0.2.2.tgz",
             "integrity": "sha1-toYXgqH0di3OQ0Aqcet6KD9EVzw="
+        },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
+            "dev": true
         },
         "rimraf": {
             "version": "2.7.1",
@@ -5494,10 +5638,16 @@
             "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
             "dev": true
         },
+        "run-parallel": {
+            "version": "1.1.10",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/run-parallel/-/run-parallel-1.1.10.tgz",
+            "integrity": "sha1-YKUbKug2Y2yBN33xbLEHNRvNE+8=",
+            "dev": true
+        },
         "rxjs": {
-            "version": "6.5.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rxjs/-/rxjs-6.5.5.tgz",
-            "integrity": "sha1-xciE4wlMjP7jG/J+uH5UzPyH+ew=",
+            "version": "6.6.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/rxjs/-/rxjs-6.6.3.tgz",
+            "integrity": "sha1-jKhGNcTaqQDA05Z6buesYCce5VI=",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -5637,6 +5787,12 @@
             "version": "3.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
+        },
+        "slash": {
+            "version": "3.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
+            "dev": true
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -5806,7 +5962,8 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "sshpk": {
             "version": "1.16.1",
@@ -6221,9 +6378,9 @@
             }
         },
         "typescript": {
-            "version": "3.9.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-3.9.3.tgz",
-            "integrity": "sha1-06yIg6l8JhOeQt9ek+7s4z1hC4o=",
+            "version": "4.0.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-4.0.5.tgz",
+            "integrity": "sha1-rp3d/RBp8ctb6z7zshcN18EzI4k=",
             "dev": true
         },
         "undefsafe": {
@@ -6356,6 +6513,12 @@
             "version": "3.4.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+        },
+        "v8-compile-cache": {
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+            "integrity": "sha1-lHHvo++RKNL3xqfKOcTda1BVsTI=",
+            "dev": true
         },
         "validate-npm-package-license": {
             "version": "3.0.4",

--- a/templates/typescript/samples/sample-assistant/package-lock.json
+++ b/templates/typescript/samples/sample-assistant/package-lock.json
@@ -23,28 +23,29 @@
             }
         },
         "@azure/cosmos": {
-            "version": "3.6.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cosmos/-/@azure/cosmos-3.6.3.tgz",
-            "integrity": "sha1-u1O941+/M4FgaR0ramL0e0qaHLs=",
+            "version": "3.9.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/cosmos/-/@azure/cosmos-3.9.3.tgz",
+            "integrity": "sha1-fpX/kuXD6dp+gxa8UMnMkovmwdY=",
             "requires": {
                 "@types/debug": "^4.1.4",
                 "debug": "^4.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
+                "jsbi": "^3.1.3",
                 "node-abort-controller": "^1.0.4",
                 "node-fetch": "^2.6.0",
-                "os-name": "^3.1.0",
                 "priorityqueuejs": "^1.0.0",
                 "semaphore": "^1.0.5",
-                "tslib": "^1.10.0",
-                "uuid": "^3.3.2"
+                "tslib": "^2.0.0",
+                "universal-user-agent": "^6.0.0",
+                "uuid": "^8.3.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -53,16 +54,26 @@
                     "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
                 },
                 "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+                    "version": "2.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
+                },
+                "tslib": {
+                    "version": "2.0.3",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-2.0.3.tgz",
+                    "integrity": "sha1-jgdBrEX8DCJuWKF7/D5kubxsphw="
+                },
+                "uuid": {
+                    "version": "8.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uuid/-/uuid-8.3.1.tgz",
+                    "integrity": "sha1-K6LmygANpg/OWhlpVKskETHgWjE="
                 }
             }
         },
         "@azure/ms-rest-js": {
-            "version": "1.8.15",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.15.tgz",
-            "integrity": "sha1-Qme2uMANhTAXkf4M80fgRVqAczg=",
+            "version": "1.9.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.9.0.tgz",
+            "integrity": "sha1-XrZRbPIOlyoutMWJ1rSMMVG8gBs=",
             "requires": {
                 "@types/tunnel": "0.0.0",
                 "axios": "^0.19.0",
@@ -75,114 +86,127 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.10.1.tgz",
-            "integrity": "sha1-1UgcUJXaocV+FuVMb5GYRDr7Sf8=",
+            "version": "7.10.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/code-frame/-/@babel/code-frame-7.10.4.tgz",
+            "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.10.1"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/generator": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.10.2.tgz",
-            "integrity": "sha1-D6W1sjiduL/fzDSStVHuIPXdaak=",
+            "version": "7.12.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/generator/-/@babel/generator-7.12.5.tgz",
+            "integrity": "sha1-osUN5ci21wirlb5eYFOTbBiEpN4=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.2",
+                "@babel/types": "^7.12.5",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.10.1.tgz",
-            "integrity": "sha1-kr1jgpv8khWsqdne+oX1a1OUVPQ=",
+            "version": "7.10.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-function-name/-/@babel/helper-function-name-7.10.4.tgz",
+            "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.10.1",
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.10.1.tgz",
-            "integrity": "sha1-cwM5CoG6fLWWE4laGSuThQ43P30=",
+            "version": "7.10.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-get-function-arity/-/@babel/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.10.1.tgz",
-            "integrity": "sha1-xvS+HLwV46ho5MZKF9XTHXVNo18=",
+            "version": "7.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-split-export-declaration/-/@babel/helper-split-export-declaration-7.11.0.tgz",
+            "integrity": "sha1-+KSRJErPamdhWKxCBykRuoOtCZ8=",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.11.0"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-validator-identifier/-/@babel/helper-validator-identifier-7.10.1.tgz",
-            "integrity": "sha1-V3CwwagmxPU/Xt5eFTFj4DGOlLU=",
+            "version": "7.10.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/helper-validator-identifier/-/@babel/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.10.1.tgz",
-            "integrity": "sha1-hB0Ji6YTuhpCeis4PXnjVVLDiuA=",
+            "version": "7.10.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/highlight/-/@babel/highlight-7.10.4.tgz",
+            "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.10.2.tgz",
-            "integrity": "sha1-hxgH8QRCuS/5fkeDubVPagyoEtA=",
+            "version": "7.12.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/parser/-/@babel/parser-7.12.5.tgz",
+            "integrity": "sha1-tK8y3dRzwL+mQ71/8HKLjnG4HqA=",
             "dev": true
         },
+        "@babel/runtime": {
+            "version": "7.12.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/runtime/-/@babel/runtime-7.12.5.tgz",
+            "integrity": "sha1-QQ5+SHRB4bNgwpvnFdhw2bmFiC4=",
+            "requires": {
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
         "@babel/template": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.10.1.tgz",
-            "integrity": "sha1-4WcVSpTLXxSyjcWPU1bSFi9TmBE=",
+            "version": "7.10.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/template/-/@babel/template-7.10.4.tgz",
+            "integrity": "sha1-MlGZbEIA68cdGo/EBfupQPNrong=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/traverse": {
-            "version": "7.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.10.1.tgz",
-            "integrity": "sha1-u87zAx5BUqbAtQFH9JWN9Uyg3Sc=",
+            "version": "7.12.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/traverse/-/@babel/traverse-7.12.5.tgz",
+            "integrity": "sha1-eKDGjI6KNeTKz9MduLswPVYG8JU=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/generator": "^7.10.1",
-                "@babel/helper-function-name": "^7.10.1",
-                "@babel/helper-split-export-declaration": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.12.5",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.12.5",
+                "@babel/types": "^7.12.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "lodash": "^4.17.13"
+                "lodash": "^4.17.19"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.2",
@@ -193,13 +217,13 @@
             }
         },
         "@babel/types": {
-            "version": "7.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.10.2.tgz",
-            "integrity": "sha1-MCg74xytDb9vsAvUBkHKDqZ1Fy0=",
+            "version": "7.12.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@babel/types/-/@babel/types-7.12.6.tgz",
+            "integrity": "sha1-rg5V7xzOH7yIHNJvgjTrPmV+3JY=",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
-                "lodash": "^4.17.13",
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -214,9 +238,9 @@
             }
         },
         "@microsoft/microsoft-graph-types": {
-            "version": "1.12.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-types/-/@microsoft/microsoft-graph-types-1.12.0.tgz",
-            "integrity": "sha1-rPPPz7ZrCXMTKYJdh3MO4GbYFIo="
+            "version": "1.26.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@microsoft/microsoft-graph-types/-/@microsoft/microsoft-graph-types-1.26.0.tgz",
+            "integrity": "sha1-+r8X0oEaZADE8mXmOdmO2G69h5o="
         },
         "@microsoft/recognizers-text": {
             "version": "1.3.0",
@@ -397,10 +421,10 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
-        "@types/atob": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/atob/-/@types/atob-2.1.2.tgz",
-            "integrity": "sha1-FX6wzEYmSoxV8ic6g2x6GmRPuCA="
+        "@types/atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/atob-lite/-/@types/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-vUTKcuZaWEd+gTCaZuQBUk8YcFM="
         },
         "@types/body-parser": {
             "version": "1.19.0",
@@ -420,12 +444,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/color-name/-/@types/color-name-1.1.1.tgz",
-            "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
-            "dev": true
-        },
         "@types/connect": {
             "version": "3.4.33",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/connect/-/@types/connect-3.4.33.tgz",
@@ -440,9 +458,9 @@
             "integrity": "sha1-sU76iFK3do2JiQZhPCP2iHE+As0="
         },
         "@types/documentdb": {
-            "version": "1.10.6",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.6.tgz",
-            "integrity": "sha1-FWwV1yDmhx3gY3HJbZPHtX7htic=",
+            "version": "1.10.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/documentdb/-/@types/documentdb-1.10.8.tgz",
+            "integrity": "sha1-zyAI+KSUSrvZcfKsHbuBq/LZL5I=",
             "requires": {
                 "@types/node": "*"
             }
@@ -526,17 +544,17 @@
             "integrity": "sha1-yJO3NyHbc2mZQ7/DZTsd63+qSjo="
         },
         "@types/moment-timezone": {
-            "version": "0.5.13",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/moment-timezone/-/@types/moment-timezone-0.5.13.tgz",
-            "integrity": "sha1-AxfMyR60x/SQFwQWYWY5XDknZSg=",
+            "version": "0.5.30",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/moment-timezone/-/@types/moment-timezone-0.5.30.tgz",
+            "integrity": "sha1-NA7UX+PnFfSgEfXPzrfLUqrUb8c=",
             "requires": {
-                "moment": ">=2.14.0"
+                "moment-timezone": "*"
             }
         },
         "@types/node": {
-            "version": "14.0.9",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-14.0.9.tgz",
-            "integrity": "sha1-Q4lquH/IK9od/WAM30SgyKZOEdI="
+            "version": "14.14.9",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-14.14.9.tgz",
+            "integrity": "sha1-BK/Jolxv+T2hTeq9ZdxESFtTyNY="
         },
         "@types/qs": {
             "version": "6.9.5",
@@ -595,9 +613,9 @@
             }
         },
         "@types/xmldom": {
-            "version": "0.1.29",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/xmldom/-/@types/xmldom-0.1.29.tgz",
-            "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E="
+            "version": "0.1.30",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/xmldom/-/@types/xmldom-0.1.30.tgz",
+            "integrity": "sha1-022afWSvRpPTsY1dwCzkMqlb4S4="
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "4.8.1",
@@ -780,27 +798,28 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "8.10.61",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.61.tgz",
-                    "integrity": "sha1-0pkTbOVLyvGrqkpIf55L7faw05M="
+                    "version": "8.10.66",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-8.10.66.tgz",
+                    "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
                 }
             }
         },
         "adaptive-expressions": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptive-expressions/-/adaptive-expressions-4.9.2.tgz",
-            "integrity": "sha1-Cj0ng3DTAQiHACEKAmZ33sY8WfY=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/adaptive-expressions/-/adaptive-expressions-4.11.0.tgz",
+            "integrity": "sha1-dB/Hz3HRj88oxFXsY2tze1gDYt8=",
             "requires": {
                 "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-                "@types/atob": "^2.1.2",
+                "@types/atob-lite": "^2.0.0",
                 "@types/lru-cache": "^5.1.0",
-                "@types/moment-timezone": "^0.5.12",
+                "@types/moment-timezone": "^0.5.13",
                 "@types/xmldom": "^0.1.29",
-                "antlr4ts": "0.5.0-alpha.1",
-                "atob": "^2.1.2",
+                "antlr4ts": "0.5.0-alpha.3",
+                "atob-lite": "^2.0.0",
                 "big-integer": "^1.6.48",
+                "d3-format": "^1.4.4",
                 "jspath": "^0.4.0",
-                "lodash": "^4.17.15",
+                "lodash": "^4.17.19",
                 "lru-cache": "^5.1.1",
                 "moment": "^2.25.1",
                 "moment-timezone": "^0.5.28"
@@ -812,9 +831,9 @@
             "integrity": "sha1-K+H3FFaT29Y+nxthKNUsMn//a4Q="
         },
         "ajv": {
-            "version": "6.12.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.12.2.tgz",
-            "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
+            "version": "6.12.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -901,19 +920,18 @@
             "dev": true
         },
         "ansi-styles": {
-            "version": "4.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
-            "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+            "version": "4.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
             "dev": true,
             "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
             }
         },
         "antlr4ts": {
-            "version": "0.5.0-alpha.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/antlr4ts/-/antlr4ts-0.5.0-alpha.1.tgz",
-            "integrity": "sha1-xCHYJpUjNWxCxVM2A67AQQtCOAY="
+            "version": "0.5.0-alpha.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+            "integrity": "sha1-+m052I1rljQaiv70WGevmryzh2Y="
         },
         "anymatch": {
             "version": "3.1.1",
@@ -935,14 +953,14 @@
             }
         },
         "applicationinsights": {
-            "version": "1.7.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.7.5.tgz",
-            "integrity": "sha1-Qj2bWM0gEX1yS4aBGTXendq4uFI=",
+            "version": "1.8.8",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/applicationinsights/-/applicationinsights-1.8.8.tgz",
+            "integrity": "sha1-/FFK8+3x/l96w2GavwPzrkYYOsA=",
             "requires": {
                 "cls-hooked": "^4.2.2",
                 "continuation-local-storage": "^3.2.1",
-                "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.4"
+                "diagnostic-channel": "0.3.1",
+                "diagnostic-channel-publishers": "0.4.2"
             }
         },
         "archy": {
@@ -955,7 +973,6 @@
             "version": "1.0.10",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
-            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -1030,10 +1047,10 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
-        "atob": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
+        "atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/atob-lite/-/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -1041,9 +1058,9 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.10.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.10.0.tgz",
-            "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI="
+            "version": "1.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/aws4/-/aws4-1.11.0.tgz",
+            "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
         },
         "axios": {
             "version": "0.19.2",
@@ -1133,9 +1150,9 @@
             "integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
         },
         "binary-extensions": {
-            "version": "2.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
-            "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/binary-extensions/-/binary-extensions-2.1.0.tgz",
+            "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
             "dev": true
         },
         "binary-search-bounds": {
@@ -1144,9 +1161,9 @@
             "integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
         },
         "bot-solutions": {
-            "version": "1.0.0",
-            "resolved": false,
-            "integrity": "sha512-+5QFNhE0VPpVoI/LP2fO6MnwoSWmJsWY3d1CIRfdy8A4XbcNcBHD3VTWgodvXD4672O1z0l66bfu2HoUMDZQMA==",
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bot-solutions/-/bot-solutions-1.0.1.tgz",
+            "integrity": "sha1-E6eD9NX09QQIjuQNOKtd9z5yiwU=",
             "requires": {
                 "@azure/cognitiveservices-luis-authoring": "^2.1.0",
                 "@microsoft/recognizers-text": "^1.1.4",
@@ -1162,161 +1179,114 @@
                 "botframework-config": "^4.9.2",
                 "botframework-connector": "^4.9.2",
                 "dayjs": "1.8.17",
+                "i18next": "^15.0.6",
+                "i18next-node-fs-backend": "^2.1.1",
                 "jwks-rsa": "1.5.0",
                 "ms-rest-azure": "^2.5.0",
-                "p-queue": "^6.0.0",
+                "p-queue": "^4.0.0",
                 "request-promise-native": "^1.0.7",
                 "uuid": "^3.3.2",
                 "xml-js": "^1.6.11"
             }
         },
         "botbuilder": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.9.2.tgz",
-            "integrity": "sha1-IObPpq0pndzey6Z39RXtdbVenGA=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder/-/botbuilder-4.11.0.tgz",
+            "integrity": "sha1-FI1rOqWbAG3t6PiCg+xxaCx8XlE=",
             "requires": {
-                "@azure/ms-rest-js": "1.2.6",
-                "@types/node": "^10.12.18",
+                "@azure/ms-rest-js": "1.9.0",
+                "@types/node": "^10.17.27",
                 "axios": "^0.19.0",
-                "botbuilder-core": "4.9.2",
-                "botframework-connector": "4.9.2",
-                "botframework-streaming": "4.9.2",
+                "botbuilder-core": "4.11.0",
+                "botframework-connector": "4.11.0",
+                "botframework-streaming": "4.11.0",
                 "filenamify": "^4.1.0",
                 "fs-extra": "^7.0.1",
                 "moment-timezone": "^0.5.28"
             },
             "dependencies": {
-                "@azure/ms-rest-js": {
-                    "version": "1.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
-                    "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
-                    "requires": {
-                        "axios": "^0.18.0",
-                        "form-data": "^2.3.2",
-                        "tough-cookie": "^2.4.3",
-                        "tslib": "^1.9.2",
-                        "uuid": "^3.2.1",
-                        "xml2js": "^0.4.19"
-                    },
-                    "dependencies": {
-                        "axios": {
-                            "version": "0.18.1",
-                            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.1.tgz",
-                            "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
-                            "requires": {
-                                "follow-redirects": "1.5.10",
-                                "is-buffer": "^2.0.2"
-                            }
-                        }
-                    }
-                },
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
-                },
-                "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+                    "version": "10.17.46",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.46.tgz",
+                    "integrity": "sha1-HNhn6/6ZV6tFlR8vcV+N5fPat6M="
                 }
             }
         },
         "botbuilder-ai": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.9.2.tgz",
-            "integrity": "sha1-08UhW2Aw8c81U4fSLCiZWP22Hxk=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-ai/-/botbuilder-ai-4.11.0.tgz",
+            "integrity": "sha1-Db1PbrauXYpnxfZKjanGPnCOK5U=",
             "requires": {
                 "@azure/cognitiveservices-luis-runtime": "2.0.0",
-                "@azure/ms-rest-js": "1.8.13",
+                "@azure/ms-rest-js": "1.9.0",
                 "@microsoft/recognizers-text-date-time": "1.1.4",
-                "@types/node": "^10.12.18",
-                "botbuilder-core": "4.9.2",
-                "botbuilder-dialogs": "4.9.2",
-                "moment": "^2.25.1",
-                "node-fetch": "^2.3.0",
+                "adaptive-expressions": "4.11.0",
+                "botbuilder-core": "4.11.0",
+                "botbuilder-dialogs": "4.11.0",
+                "node-fetch": "^2.6.0",
                 "url-parse": "^1.4.4"
             },
             "dependencies": {
-                "@azure/ms-rest-js": {
-                    "version": "1.8.13",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.8.13.tgz",
-                    "integrity": "sha1-7QzYZGlpc3jNOdedVYnod6O8h6Y=",
-                    "requires": {
-                        "@types/tunnel": "0.0.0",
-                        "axios": "^0.19.0",
-                        "form-data": "^2.3.2",
-                        "tough-cookie": "^2.4.3",
-                        "tslib": "^1.9.2",
-                        "tunnel": "0.0.6",
-                        "uuid": "^3.2.1",
-                        "xml2js": "^0.4.19"
-                    }
-                },
-                "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
-                },
                 "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+                    "version": "2.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
                 }
             }
         },
         "botbuilder-applicationinsights": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.9.2.tgz",
-            "integrity": "sha1-FO/SCLrE8hK64mMJQdoqkHquPo0=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-applicationinsights/-/botbuilder-applicationinsights-4.11.0.tgz",
+            "integrity": "sha1-M3fXILpQiqR5/M90ejLPk9Gx9Us=",
             "requires": {
-                "applicationinsights": "1.7.5",
-                "botbuilder-core": "4.9.2",
+                "applicationinsights": "^1.7.5",
+                "botbuilder-core": "4.11.0",
                 "cls-hooked": "^4.2.2"
             }
         },
         "botbuilder-azure": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.9.2.tgz",
-            "integrity": "sha1-eNahVxGxk2UTQgibEqmsyhX2rJ8=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-azure/-/botbuilder-azure-4.11.0.tgz",
+            "integrity": "sha1-iidOyODCn1AFcmoDBgn5kY65ly0=",
             "requires": {
                 "@azure/cosmos": "^3.3.1",
                 "@types/documentdb": "^1.10.5",
-                "@types/node": "^10.12.18",
+                "@types/node": "^10.17.27",
                 "azure-storage": "2.10.2",
-                "botbuilder": "4.9.2",
+                "botbuilder": "4.11.0",
                 "documentdb": "1.14.5",
                 "flat": "^4.0.0",
                 "semaphore": "^1.1.0"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
+                    "version": "10.17.46",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.46.tgz",
+                    "integrity": "sha1-HNhn6/6ZV6tFlR8vcV+N5fPat6M="
                 }
             }
         },
         "botbuilder-core": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.9.2.tgz",
-            "integrity": "sha1-njBevc19gjHXH/OOZlPjb7uRxes=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-core/-/botbuilder-core-4.11.0.tgz",
+            "integrity": "sha1-QVTg6299RdaTv8yQBZTnJBNgkUQ=",
             "requires": {
                 "assert": "^1.4.1",
-                "botframework-schema": "4.9.2"
+                "botframework-connector": "4.11.0",
+                "botframework-schema": "4.11.0"
             }
         },
         "botbuilder-dialogs": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.9.2.tgz",
-            "integrity": "sha1-J6gzfowfrJaVm/JObykgJeD8Aj8=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-dialogs/-/botbuilder-dialogs-4.11.0.tgz",
+            "integrity": "sha1-5YVTsmtSCrbRCbAFOoGH6s9X88A=",
             "requires": {
                 "@microsoft/recognizers-text-choice": "1.1.4",
                 "@microsoft/recognizers-text-date-time": "1.1.4",
                 "@microsoft/recognizers-text-number": "1.1.4",
                 "@microsoft/recognizers-text-suite": "1.1.4",
-                "@types/node": "^10.12.18",
-                "botbuilder-core": "4.9.2",
+                "@types/node": "^10.17.27",
+                "botbuilder-core": "4.11.0",
                 "globalize": "^1.4.2"
             },
             "dependencies": {
@@ -1335,102 +1305,61 @@
                     }
                 },
                 "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
+                    "version": "10.17.46",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.46.tgz",
+                    "integrity": "sha1-HNhn6/6ZV6tFlR8vcV+N5fPat6M="
                 }
             }
         },
         "botbuilder-lg": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-lg/-/botbuilder-lg-4.9.2.tgz",
-            "integrity": "sha1-zesI6lBPlwJLl7wPSIYz2Ij2/0I=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botbuilder-lg/-/botbuilder-lg-4.11.0.tgz",
+            "integrity": "sha1-GDojFELxjklN8aAL3sfPASh86GQ=",
             "requires": {
-                "adaptive-expressions": "4.9.2",
-                "antlr4ts": "0.5.0-alpha.1",
-                "lodash": "^4.17.11",
+                "adaptive-expressions": "4.11.0",
+                "antlr4ts": "0.5.0-alpha.3",
+                "lodash": "^4.17.19",
                 "path": "^0.12.7",
-                "uuid": "^3.3.3"
+                "uuid": "^3.4.0"
             }
         },
         "botframework-config": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.9.2.tgz",
-            "integrity": "sha1-qFjKv/4+0ohWgtqaKetjX+SHlS4=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-config/-/botframework-config-4.11.0.tgz",
+            "integrity": "sha1-3Dc6rkW6grcLJ+tcPvN5g5XL4OM=",
             "requires": {
-                "fs-extra": "^7.0.0",
+                "fs-extra": "^7.0.1",
                 "read-text-file": "^1.1.0",
-                "uuid": "^3.3.2"
+                "uuid": "^3.4.0"
             }
         },
         "botframework-connector": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.9.2.tgz",
-            "integrity": "sha1-OS2NKEhrIXAm8GafphNCXeIOtNM=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-connector/-/botframework-connector-4.11.0.tgz",
+            "integrity": "sha1-/fQVMNoTK0XaiGomaALKh7y/8UQ=",
             "requires": {
-                "@azure/ms-rest-js": "1.2.6",
+                "@azure/ms-rest-js": "1.9.0",
                 "@types/jsonwebtoken": "7.2.8",
-                "@types/node": "^10.12.18",
                 "adal-node": "0.2.1",
                 "base64url": "^3.0.0",
-                "botframework-schema": "4.9.2",
-                "form-data": "^2.3.3",
+                "botframework-schema": "4.11.0",
+                "cross-fetch": "^3.0.5",
                 "jsonwebtoken": "8.0.1",
-                "node-fetch": "^2.2.1",
                 "rsa-pem-from-mod-exp": "^0.8.4"
-            },
-            "dependencies": {
-                "@azure/ms-rest-js": {
-                    "version": "1.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@azure/ms-rest-js/-/@azure/ms-rest-js-1.2.6.tgz",
-                    "integrity": "sha1-Lr1PkiZ38xQ3yC9PYmzsne9NMs0=",
-                    "requires": {
-                        "axios": "^0.18.0",
-                        "form-data": "^2.3.2",
-                        "tough-cookie": "^2.4.3",
-                        "tslib": "^1.9.2",
-                        "uuid": "^3.2.1",
-                        "xml2js": "^0.4.19"
-                    }
-                },
-                "@types/node": {
-                    "version": "10.17.24",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/@types/node/-/@types/node-10.17.24.tgz",
-                    "integrity": "sha1-xXUR46GcS16WkrsplcQKOlIWeUQ="
-                },
-                "axios": {
-                    "version": "0.18.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/axios/-/axios-0.18.1.tgz",
-                    "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
-                    "requires": {
-                        "follow-redirects": "1.5.10",
-                        "is-buffer": "^2.0.2"
-                    }
-                },
-                "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
-                },
-                "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
-                }
             }
         },
         "botframework-schema": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.9.2.tgz",
-            "integrity": "sha1-Lb7G+5WzRDf6QetzVN4qWjU4Oyo="
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-schema/-/botframework-schema-4.11.0.tgz",
+            "integrity": "sha1-54Ue7nYogwISnYfYSEhOdyzlyAw="
         },
         "botframework-streaming": {
-            "version": "4.9.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-streaming/-/botframework-streaming-4.9.2.tgz",
-            "integrity": "sha1-Vg5Af11EqxKJfZcGqII8Pk2sYJ0=",
+            "version": "4.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/botframework-streaming/-/botframework-streaming-4.11.0.tgz",
+            "integrity": "sha1-y41ZB0tMruHkm49e4H0Dlu2pi58=",
             "requires": {
                 "@types/ws": "^6.0.3",
-                "uuid": "^3.3.2",
+                "uuid": "^3.4.0",
                 "ws": "^7.1.2"
             }
         },
@@ -1467,9 +1396,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+                    "version": "7.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -1512,12 +1441,12 @@
             "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "bunyan": {
-            "version": "1.8.12",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bunyan/-/bunyan-1.8.12.tgz",
-            "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+            "version": "1.8.14",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/bunyan/-/bunyan-1.8.14.tgz",
+            "integrity": "sha1-PYwa/qfeFYpSOMfLimarazjdRbQ=",
             "requires": {
                 "dtrace-provider": "~0.8",
-                "moment": "^2.10.6",
+                "moment": "^2.19.3",
                 "mv": "~2",
                 "safe-json-stringify": "~1"
             }
@@ -1538,9 +1467,9 @@
             },
             "dependencies": {
                 "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha1-ASA83JJZf5uQkGfD5lbMH008Tck=",
+                    "version": "5.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
                     "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
@@ -1587,6 +1516,16 @@
                         "signal-exit": "^3.0.2"
                     }
                 }
+            }
+        },
+        "call-bind": {
+            "version": "1.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/call-bind/-/call-bind-1.0.0.tgz",
+            "integrity": "sha1-JBJwVLs/m9y0sfuCQYGGBy93uM4=",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.0"
             }
         },
         "callsites": {
@@ -1676,9 +1615,9 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.4.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-3.4.0.tgz",
-            "integrity": "sha1-swYRQjzjdjV8dlubj5BLn7o8C+g=",
+            "version": "3.4.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/chokidar/-/chokidar-3.4.3.tgz",
+            "integrity": "sha1-wd84IxRI5FykrFiObHlXO6alfVs=",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.1",
@@ -1688,7 +1627,7 @@
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.4.0"
+                "readdirp": "~3.5.0"
             }
         },
         "ci-info": {
@@ -1698,14 +1637,14 @@
             "dev": true
         },
         "cldrjs": {
-            "version": "0.5.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cldrjs/-/cldrjs-0.5.1.tgz",
-            "integrity": "sha1-tdxL6uAlVWNLBLlN644i4T/xAxk="
+            "version": "0.5.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cldrjs/-/cldrjs-0.5.5.tgz",
+            "integrity": "sha1-XJLKLeiaihbep2yy38TgAQRCjlI="
         },
         "cli-boxes": {
-            "version": "2.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-2.2.0.tgz",
-            "integrity": "sha1-U47K6PnGylCOPDyVtFP+k8tMFo0=",
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cli-boxes/-/cli-boxes-2.2.1.tgz",
+            "integrity": "sha1-3dUDXSUJT84iDpyrQKRYQKRAMY8=",
             "dev": true
         },
         "cli-cursor": {
@@ -1828,9 +1767,9 @@
             }
         },
         "copyfiles": {
-            "version": "2.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.3.0.tgz",
-            "integrity": "sha1-HCbrvj1Gu6LTCaP9jjqsz1OvjHY=",
+            "version": "2.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/copyfiles/-/copyfiles-2.4.0.tgz",
+            "integrity": "sha1-/KxypPK4gvAh3RVrS89tcTFUh70=",
             "dev": true,
             "requires": {
                 "glob": "^7.0.5",
@@ -1838,6 +1777,7 @@
                 "mkdirp": "^1.0.4",
                 "noms": "0.0.0",
                 "through2": "^2.0.1",
+                "untildify": "^4.0.0",
                 "yargs": "^15.3.1"
             },
             "dependencies": {
@@ -1893,10 +1833,26 @@
                 }
             }
         },
+        "cross-fetch": {
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-fetch/-/cross-fetch-3.0.6.tgz",
+            "integrity": "sha1-OkBAvIlB5lPg6c8X8p680XfTNlw=",
+            "requires": {
+                "node-fetch": "2.6.1"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
+                }
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
             "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+            "dev": true,
             "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -1929,19 +1885,24 @@
             }
         },
         "csv-generate": {
-            "version": "3.2.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-3.2.4.tgz",
-            "integrity": "sha1-RA2rkXcznuBnbJ5cFvUOKzRjwBk="
+            "version": "3.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-generate/-/csv-generate-3.3.0.tgz",
+            "integrity": "sha1-DiVljxu5gG2U/seycIlqNcfu3xo="
         },
         "csv-parse": {
-            "version": "4.10.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-4.10.1.tgz",
-            "integrity": "sha1-Hia6Y9KcdelNDrpunemoqvidcqY="
+            "version": "4.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-parse/-/csv-parse-4.14.1.tgz",
+            "integrity": "sha1-trNzZQj7lGgvptRQ/hdVI3Ih0pE="
         },
         "csv-stringify": {
-            "version": "5.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-5.5.0.tgz",
-            "integrity": "sha1-C96q9g1uFbicdSoOzrS0wsivWoo="
+            "version": "5.5.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/csv-stringify/-/csv-stringify-5.5.3.tgz",
+            "integrity": "sha1-t6KH2u50kt43IrE9zLI48tYNtSI="
+        },
+        "d3-format": {
+            "version": "1.4.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/d3-format/-/d3-format-1.4.5.tgz",
+            "integrity": "sha1-N08roTIONxfrdKk1bGfa7hen7bQ="
         },
         "dashdash": {
             "version": "1.14.1",
@@ -2064,17 +2025,17 @@
             "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw="
         },
         "diagnostic-channel": {
-            "version": "0.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+            "version": "0.3.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+            "integrity": "sha1-f6oUPhB/hhvjBGU560kI+qs/U/0=",
             "requires": {
                 "semver": "^5.3.0"
             }
         },
         "diagnostic-channel-publishers": {
-            "version": "0.3.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
-            "integrity": "sha1-2GKlFWCQCT4NEvblno07EZ76lWM="
+            "version": "0.4.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.2.tgz",
+            "integrity": "sha1-4THZw1HUt8a8uekB5Cu3378J/8M="
         },
         "diff": {
             "version": "3.5.0",
@@ -2089,14 +2050,6 @@
             "dev": true,
             "requires": {
                 "path-type": "^4.0.0"
-            },
-            "dependencies": {
-                "path-type": {
-                    "version": "4.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-type/-/path-type-4.0.0.tgz",
-                    "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
-                    "dev": true
-                }
             }
         },
         "doctrine": {
@@ -2140,9 +2093,9 @@
             }
         },
         "dot-prop": {
-            "version": "5.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-5.2.0.tgz",
-            "integrity": "sha1-w07MKVVtxF8fTCJpe29JBODMT8s=",
+            "version": "5.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
             "dev": true,
             "requires": {
                 "is-obj": "^2.0.0"
@@ -2210,17 +2163,18 @@
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "encoding": {
-            "version": "0.1.12",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/encoding/-/encoding-0.1.12.tgz",
-            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "version": "0.1.13",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/encoding/-/encoding-0.1.13.tgz",
+            "integrity": "sha1-VldK/deR9UqOmyeFwFgqLSYhD6k=",
             "requires": {
-                "iconv-lite": "~0.4.13"
+                "iconv-lite": "^0.6.2"
             }
         },
         "end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -2235,22 +2189,36 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.17.5.tgz",
-            "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
+            "version": "1.17.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.17.7.tgz",
+            "integrity": "sha1-pN5hsvZpifx0IWdsHLl4dXOs5Uw=",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1",
-                "is-callable": "^1.1.5",
-                "is-regex": "^1.0.5",
-                "object-inspect": "^1.7.0",
+                "is-callable": "^1.2.2",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
-                "string.prototype.trimleft": "^2.1.1",
-                "string.prototype.trimright": "^2.1.1"
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+            },
+            "dependencies": {
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "es-to-primitive": {
@@ -2371,15 +2339,6 @@
                     "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
                     "dev": true
                 },
-                "globals": {
-                    "version": "12.4.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-12.4.0.tgz",
-                    "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
-                    "dev": true,
-                    "requires": {
-                        "type-fest": "^0.8.1"
-                    }
-                },
                 "ignore": {
                     "version": "4.0.6",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ignore/-/ignore-4.0.6.tgz",
@@ -2412,12 +2371,6 @@
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }
-                },
-                "strip-json-comments": {
-                    "version": "3.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-                    "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
-                    "dev": true
                 }
             }
         },
@@ -2482,8 +2435,7 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
-            "dev": true
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
         },
         "esquery": {
             "version": "1.3.1",
@@ -2537,9 +2489,9 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8="
+            "version": "3.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc="
         },
         "ewma": {
             "version": "2.0.1",
@@ -2547,20 +2499,6 @@
             "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
             "requires": {
                 "assert-plus": "^1.0.0"
-            }
-        },
-        "execa": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/execa/-/execa-1.0.0.tgz",
-            "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
-            "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
             }
         },
         "extend": {
@@ -2577,6 +2515,17 @@
                 "chardet": "^0.7.0",
                 "iconv-lite": "^0.4.24",
                 "tmp": "^0.0.33"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
             }
         },
         "extsprintf": {
@@ -2590,9 +2539,9 @@
             "integrity": "sha1-Rvi2wisw/3qBNX1PWav66TggJUM="
         },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ="
+            "version": "3.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
         },
         "fast-glob": {
             "version": "3.2.4",
@@ -2652,9 +2601,9 @@
             "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
         },
         "filenamify": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-4.1.0.tgz",
-            "integrity": "sha1-VNEQgQrnTuv+EVwbmVvQfgPPIYQ=",
+            "version": "4.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/filenamify/-/filenamify-4.2.0.tgz",
+            "integrity": "sha1-yZcW1naGlYWztdMos/BlkNAy6J8=",
             "requires": {
                 "filename-reserved-regex": "^2.0.0",
                 "strip-outer": "^1.0.1",
@@ -2694,9 +2643,9 @@
             }
         },
         "find-my-way": {
-            "version": "2.2.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.2.3.tgz",
-            "integrity": "sha1-Up9ZadvR5uvtZ0p6EIfDQwmI454=",
+            "version": "2.2.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/find-my-way/-/find-my-way-2.2.5.tgz",
+            "integrity": "sha1-hs6CUmb6KM2WLlOKRewqqoTD1RQ=",
             "requires": {
                 "fast-decode-uri-component": "^1.0.0",
                 "safe-regex2": "^2.0.0",
@@ -2714,17 +2663,17 @@
             }
         },
         "flat": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.0.tgz",
-            "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+            "version": "4.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/flat/-/flat-4.1.1.tgz",
+            "integrity": "sha1-o5IFnMOCiB/5hkL12k3eCpWfMJs=",
             "requires": {
                 "is-buffer": "~2.0.3"
             },
             "dependencies": {
                 "is-buffer": {
-                    "version": "2.0.4",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.4.tgz",
-                    "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+                    "version": "2.0.5",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha1-68JS5ADSL/jXf6CYiIIaJKZYwZE="
                 }
             }
         },
@@ -2888,10 +2837,22 @@
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
+        "get-intrinsic": {
+            "version": "1.0.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+            "integrity": "sha1-lKl2j8vdBZWhySc6rPTInQdWMb4=",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
+        },
         "get-stream": {
             "version": "4.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/get-stream/-/get-stream-4.1.0.tgz",
             "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+            "dev": true,
             "requires": {
                 "pump": "^3.0.0"
             }
@@ -2936,18 +2897,21 @@
             }
         },
         "globalize": {
-            "version": "1.5.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globalize/-/globalize-1.5.0.tgz",
-            "integrity": "sha1-w0Gd54uS0+/uDVTm2jiJNMe0WxE=",
+            "version": "1.6.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globalize/-/globalize-1.6.0.tgz",
+            "integrity": "sha1-tsZZz6akf6GoJ5GHpFaJVg2FkbE=",
             "requires": {
-                "cldrjs": "^0.5.0"
+                "cldrjs": "^0.5.4"
             }
         },
         "globals": {
-            "version": "11.12.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
-            "dev": true
+            "version": "12.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/globals/-/globals-12.4.0.tgz",
+            "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
+            "dev": true,
+            "requires": {
+                "type-fest": "^0.8.1"
+            }
         },
         "globby": {
             "version": "11.0.1",
@@ -3009,11 +2973,11 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+            "version": "5.1.5",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
             }
         },
@@ -3148,12 +3112,29 @@
                 "sshpk": "^1.7.0"
             }
         },
-        "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+        "i18next": {
+            "version": "15.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next/-/i18next-15.1.3.tgz",
+            "integrity": "sha1-8ZhMvuDjywDP+QCLA3JkKJzohAo=",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "@babel/runtime": "^7.3.1"
+            }
+        },
+        "i18next-node-fs-backend": {
+            "version": "2.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/i18next-node-fs-backend/-/i18next-node-fs-backend-2.1.3.tgz",
+            "integrity": "sha1-SD+p7aTBUtYqOlW8ripXJ7qIdVk=",
+            "requires": {
+                "js-yaml": "3.13.1",
+                "json5": "2.0.0"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.6.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.6.2.tgz",
+            "integrity": "sha1-zhPRh1sMOmdL1qBLf3awGxtt7QE=",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
             }
         },
         "ignore": {
@@ -3247,12 +3228,6 @@
                     "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
                     "dev": true
                 },
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=",
-                    "dev": true
-                },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
@@ -3296,9 +3271,9 @@
             "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
         },
         "is-callable": {
-            "version": "1.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.2.0.tgz",
-            "integrity": "sha1-gzNlYLVKOONeOi33r9BFTWkUaLs=",
+            "version": "1.2.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-callable/-/is-callable-1.2.2.tgz",
+            "integrity": "sha1-x8ZxXNItTdtI0+GZcCI6zquwgNk=",
             "dev": true
         },
         "is-ci": {
@@ -3308,6 +3283,15 @@
             "dev": true,
             "requires": {
                 "ci-info": "^2.0.0"
+            }
+        },
+        "is-core-module": {
+            "version": "2.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-core-module/-/is-core-module-2.1.0.tgz",
+            "integrity": "sha1-pMwDHZsaymPuy9GKZQ4Ty07quUY=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
             }
         },
         "is-date-object": {
@@ -3347,6 +3331,12 @@
                 "is-path-inside": "^3.0.1"
             }
         },
+        "is-negative-zero": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+            "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+            "dev": true
+        },
         "is-npm": {
             "version": "4.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-npm/-/is-npm-4.0.0.tgz",
@@ -3372,12 +3362,12 @@
             "dev": true
         },
         "is-regex": {
-            "version": "1.0.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.0.5.tgz",
-            "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+            "version": "1.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/is-regex/-/is-regex-1.1.1.tgz",
+            "integrity": "sha1-xvmKrMVG9s7FRooHt7FTq1ZKV7k=",
             "dev": true,
             "requires": {
-                "has": "^1.0.3"
+                "has-symbols": "^1.0.1"
             }
         },
         "is-stream": {
@@ -3413,7 +3403,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isomorphic-fetch": {
             "version": "2.2.1",
@@ -3513,12 +3504,12 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "make-dir": {
@@ -3564,11 +3555,15 @@
             "version": "3.13.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/js-yaml/-/js-yaml-3.13.1.tgz",
             "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
-            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
+        },
+        "jsbi": {
+            "version": "3.1.4",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/jsbi/-/jsbi-3.1.4.tgz",
+            "integrity": "sha1-llTdAiB6ZqSRG05Lt0JlvCy8ndA="
         },
         "jsbn": {
             "version": "0.1.1",
@@ -3626,6 +3621,14 @@
             "version": "5.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "json5": {
+            "version": "2.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/json5/-/json5-2.0.0.tgz",
+            "integrity": "sha1-thq/l6oXjEtYU6ZsyO7K/QMEXXg=",
+            "requires": {
+                "minimist": "^1.2.0"
+            }
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -3783,9 +3786,9 @@
             "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+            "version": "4.17.20",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
         },
         "lodash.escaperegexp": {
             "version": "4.1.2",
@@ -3913,11 +3916,6 @@
                 }
             }
         },
-        "macos-release": {
-            "version": "2.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/macos-release/-/macos-release-2.3.0.tgz",
-            "integrity": "sha1-6xkwsDbAgArevM1fF7xMEt6Ltx8="
-        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/make-dir/-/make-dir-3.1.0.tgz",
@@ -3936,14 +3934,14 @@
             }
         },
         "md5": {
-            "version": "2.2.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5/-/md5-2.2.1.tgz",
-            "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+            "version": "2.3.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/md5/-/md5-2.3.0.tgz",
+            "integrity": "sha1-w9qaaq46MLRreww0m4exENw72k8=",
             "dev": true,
             "requires": {
-                "charenc": "~0.0.1",
-                "crypt": "~0.0.1",
-                "is-buffer": "~1.1.1"
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
             }
         },
         "md5.js": {
@@ -4037,9 +4035,9 @@
             "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
         },
         "mixme": {
-            "version": "0.3.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixme/-/mixme-0.3.5.tgz",
-            "integrity": "sha1-MEZSza8ko98EhyBeYaxhYsaQbd0="
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/mixme/-/mixme-0.4.0.tgz",
+            "integrity": "sha1-oa7ifw1jzJBeHMbdyYq/lNQUQ14="
         },
         "mkdirp": {
             "version": "0.5.5",
@@ -4225,6 +4223,12 @@
                         "ansi-regex": "^4.1.0"
                     }
                 },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "6.0.0",
                     "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-6.0.0.tgz",
@@ -4315,14 +4319,14 @@
             }
         },
         "moment": {
-            "version": "2.26.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.26.0.tgz",
-            "integrity": "sha1-Xh+Cxrr8pug+gIswyHBe7Q3L05o="
+            "version": "2.29.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment/-/moment-2.29.1.tgz",
+            "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
         },
         "moment-timezone": {
-            "version": "0.5.31",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment-timezone/-/moment-timezone-0.5.31.tgz",
-            "integrity": "sha1-nEDYxQJvDHq0bto9Y+ScFVFI3gU=",
+            "version": "0.5.32",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/moment-timezone/-/moment-timezone-0.5.32.tgz",
+            "integrity": "sha1-23Z3zDzGgP0wMD69kLDaHKDf7MI=",
             "requires": {
                 "moment": ">= 2.9.0"
             }
@@ -4427,9 +4431,9 @@
             }
         },
         "nan": {
-            "version": "2.14.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.1.tgz",
-            "integrity": "sha1-174036MQW5FJTDFHCJMV7/iHSwE=",
+            "version": "2.14.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
             "optional": true
         },
         "natural-compare": {
@@ -4458,7 +4462,8 @@
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
         },
         "nock": {
             "version": "10.0.6",
@@ -4478,12 +4483,12 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -4495,9 +4500,9 @@
             }
         },
         "node-abort-controller": {
-            "version": "1.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-abort-controller/-/node-abort-controller-1.0.4.tgz",
-            "integrity": "sha1-QJXkHViy+uFp0vmJKQTWA+Ecejk="
+            "version": "1.1.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/node-abort-controller/-/node-abort-controller-1.1.0.tgz",
+            "integrity": "sha1-inNKYxsCKvKZY75yRcFIPLueBw0="
         },
         "node-environment-flags": {
             "version": "1.0.5",
@@ -4519,9 +4524,9 @@
             }
         },
         "nodemon": {
-            "version": "2.0.4",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-2.0.4.tgz",
-            "integrity": "sha1-VbCTGetIjWOUqpgYFIwMLRwExBY=",
+            "version": "2.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/nodemon/-/nodemon-2.0.6.tgz",
+            "integrity": "sha1-Gr4ZN7RjqvYvDVLit+qt8ozCJA0=",
             "dev": true,
             "requires": {
                 "chokidar": "^3.2.2",
@@ -4532,14 +4537,14 @@
                 "semver": "^5.7.1",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
-                "undefsafe": "^2.0.2",
-                "update-notifier": "^4.0.0"
+                "undefsafe": "^2.0.3",
+                "update-notifier": "^4.1.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+                    "version": "3.2.7",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -4621,14 +4626,6 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/normalize-url/-/normalize-url-4.5.0.tgz",
             "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
             "dev": true
-        },
-        "npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "requires": {
-                "path-key": "^2.0.0"
-            }
         },
         "nyc": {
             "version": "14.1.1",
@@ -4846,19 +4843,53 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-inspect": {
-            "version": "1.7.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-inspect/-/object-inspect-1.7.0.tgz",
-            "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+            "version": "1.8.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-inspect/-/object-inspect-1.8.0.tgz",
+            "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
             "dev": true
         },
         "object-is": {
-            "version": "1.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-is/-/object-is-1.1.2.tgz",
-            "integrity": "sha1-xdLof/nhGfeLegiEQVGeLuwVc7Y=",
+            "version": "1.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object-is/-/object-is-1.1.3.tgz",
+            "integrity": "sha1-LjueZVYBN0Ve471irsTZCi6hzIE=",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "object-keys": {
@@ -4939,15 +4970,6 @@
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
-        "os-name": {
-            "version": "3.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-name/-/os-name-3.1.0.tgz",
-            "integrity": "sha1-3sGdlmKW4c1i1wGlpm7h3ernCAE=",
-            "requires": {
-                "macos-release": "^2.2.0",
-                "windows-release": "^3.1.0"
-            }
-        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -4959,11 +4981,6 @@
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
             "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
             "dev": true
-        },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
             "version": "2.3.0",
@@ -4984,20 +5001,11 @@
             }
         },
         "p-queue": {
-            "version": "6.6.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-queue/-/p-queue-6.6.2.tgz",
-            "integrity": "sha1-IGip3PjmfdDsPnory3aBD6qF5CY=",
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-queue/-/p-queue-4.0.0.tgz",
+            "integrity": "sha1-7Q7uh5iSftbywvX1t3/bIGGl00Y=",
             "requires": {
-                "eventemitter3": "^4.0.4",
-                "p-timeout": "^3.2.0"
-            }
-        },
-        "p-timeout": {
-            "version": "3.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/p-timeout/-/p-timeout-3.2.0.tgz",
-            "integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
-            "requires": {
-                "p-finally": "^1.0.0"
+                "eventemitter3": "^3.1.0"
             }
         },
         "p-try": {
@@ -5080,7 +5088,8 @@
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
         },
         "path-parse": {
             "version": "1.0.6",
@@ -5089,21 +5098,10 @@
             "dev": true
         },
         "path-type": {
-            "version": "3.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
-            "dev": true,
-            "requires": {
-                "pify": "^3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
-            }
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
+            "dev": true
         },
         "pathval": {
             "version": "1.1.0",
@@ -5123,11 +5121,11 @@
             "dev": true
         },
         "pidusage": {
-            "version": "2.0.20",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-2.0.20.tgz",
-            "integrity": "sha1-IGrZLwhsiSwBTc+5FZkJ6uwHLhg=",
+            "version": "2.0.21",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pidusage/-/pidusage-2.0.21.tgz",
+            "integrity": "sha1-cGiWez2VK66nPldmjJi56qh2iU4=",
             "requires": {
-                "safe-buffer": "^5.1.2"
+                "safe-buffer": "^5.2.1"
             }
         },
         "pify": {
@@ -5240,6 +5238,7 @@
             "version": "3.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pump/-/pump-3.0.0.tgz",
             "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -5251,9 +5250,9 @@
             "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
         },
         "pupa": {
-            "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pupa/-/pupa-2.0.1.tgz",
-            "integrity": "sha1-29yf9I/76komoGm2+fersFEAhyY=",
+            "version": "2.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pupa/-/pupa-2.1.1.tgz",
+            "integrity": "sha1-9ej9SvwsXZeCj6pSNUnth0SiDWI=",
             "dev": true,
             "requires": {
                 "escape-goat": "^2.0.0"
@@ -5265,9 +5264,9 @@
             "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
         },
         "querystringify": {
-            "version": "2.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha1-YOWl/WSn+L+k0qsu1v30yFutFU4="
+            "version": "2.2.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y="
         },
         "range-parser": {
             "version": "1.2.1",
@@ -5284,6 +5283,14 @@
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "dev": true
+                }
             }
         },
         "read-pkg": {
@@ -5295,6 +5302,23 @@
                 "load-json-file": "^4.0.0",
                 "normalize-package-data": "^2.3.2",
                 "path-type": "^3.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
             }
         },
         "read-pkg-up": {
@@ -5350,6 +5374,16 @@
             "requires": {
                 "iconv-lite": "^0.4.17",
                 "jschardet": "^1.4.2"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
             }
         },
         "readable-stream": {
@@ -5373,13 +5407,18 @@
             }
         },
         "readdirp": {
-            "version": "3.4.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-3.4.0.tgz",
-            "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
+            "version": "3.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha1-m6dMAZsV02UnjS6Ru4xI17TULJ4=",
             "dev": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }
+        },
+        "regenerator-runtime": {
+            "version": "0.13.7",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+            "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U="
         },
         "regexp.prototype.flags": {
             "version": "1.3.0",
@@ -5398,9 +5437,9 @@
             "dev": true
         },
         "registry-auth-token": {
-            "version": "4.1.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-            "integrity": "sha1-QKM74eglOUYPlDKLD38PhMFtlHk=",
+            "version": "4.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+            "integrity": "sha1-bXtABkQZGJcszV/tzUHcMix5slA=",
             "dev": true,
             "requires": {
                 "rc": "^1.2.8"
@@ -5469,13 +5508,6 @@
             "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
             "requires": {
                 "lodash": "^4.17.19"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
-                }
             }
         },
         "request-promise-native": {
@@ -5506,11 +5538,12 @@
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "resolve": {
-            "version": "1.17.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.17.0.tgz",
-            "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+            "version": "1.19.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/resolve/-/resolve-1.19.0.tgz",
+            "integrity": "sha1-GvW/YwQJc0oGfK4pMYqsf6KaJnw=",
             "dev": true,
             "requires": {
+                "is-core-module": "^2.1.0",
                 "path-parse": "^1.0.6"
             }
         },
@@ -5769,6 +5802,7 @@
             "version": "1.2.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -5776,7 +5810,8 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "shimmer": {
             "version": "1.2.1",
@@ -5786,7 +5821,8 @@
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw="
+            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+            "dev": true
         },
         "slash": {
             "version": "3.0.0",
@@ -5884,9 +5920,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+            "version": "3.0.6",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+            "integrity": "sha1-yAdXODwoq/cpZ0SZjLwQaui4VM4=",
             "dev": true
         },
         "spdy": {
@@ -5902,11 +5938,11 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -5930,11 +5966,11 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "version": "4.3.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "inherits": {
@@ -5962,8 +5998,7 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
             "version": "1.16.1",
@@ -5997,11 +6032,11 @@
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
         },
         "stream-transform": {
-            "version": "2.0.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-2.0.2.tgz",
-            "integrity": "sha1-PLehTIAus5vEDKqrBTXlhPOmXK8=",
+            "version": "2.0.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/stream-transform/-/stream-transform-2.0.3.tgz",
+            "integrity": "sha1-4/a6x4t9gaFFK/hL7p80CheGvWA=",
             "requires": {
-                "mixme": "^0.3.1"
+                "mixme": "^0.4.0"
             }
         },
         "string-width": {
@@ -6016,45 +6051,91 @@
             }
         },
         "string.prototype.trimend": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-            "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+            "integrity": "sha1-bd2ah5a8cUtImjriIkaiCPN7+kY=",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
-            }
-        },
-        "string.prototype.trimleft": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-            "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimstart": "^1.0.0"
-            }
-        },
-        "string.prototype.trimright": {
-            "version": "2.1.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-            "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimend": "^1.0.0"
+                "es-abstract": "^1.18.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "string.prototype.trimstart": {
-            "version": "1.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-            "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+            "version": "1.0.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+            "integrity": "sha1-ItRdqBAVMJzQzdeXh+iRn8XGE+c=",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "string_decoder": {
@@ -6080,15 +6161,10 @@
             "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
             "dev": true
         },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-        },
         "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "version": "3.1.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
             "dev": true
         },
         "strip-outer": {
@@ -6161,9 +6237,9 @@
             }
         },
         "term-size": {
-            "version": "2.2.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-2.2.0.tgz",
-            "integrity": "sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M=",
+            "version": "2.2.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/term-size/-/term-size-2.2.1.tgz",
+            "integrity": "sha1-KmpUhAQywvtjIP6g9BVTHpAYn1Q=",
             "dev": true
         },
         "test-exclude": {
@@ -6316,9 +6392,9 @@
             }
         },
         "tslib": {
-            "version": "1.13.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.13.0.tgz",
-            "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM="
+            "version": "1.14.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA="
         },
         "tsutils": {
             "version": "3.17.1",
@@ -6378,9 +6454,9 @@
             }
         },
         "typescript": {
-            "version": "4.0.5",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-4.0.5.tgz",
-            "integrity": "sha1-rp3d/RBp8ctb6z7zshcN18EzI4k=",
+            "version": "4.1.2",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/typescript/-/typescript-4.1.2.tgz",
+            "integrity": "sha1-Y2nvIlFv5eEDBKrlpcSGLbVTgOk=",
             "dev": true
         },
         "undefsafe": {
@@ -6404,9 +6480,9 @@
             }
         },
         "underscore": {
-            "version": "1.10.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.10.2.tgz",
-            "integrity": "sha1-c9aqNmjzGI5K2w8ZQ70Sz9fvqq8="
+            "version": "1.11.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/underscore/-/underscore-1.11.0.tgz",
+            "integrity": "sha1-3XwjoZXbNCZxhgRGSYcP8bq1kp4="
         },
         "unique-string": {
             "version": "2.0.0",
@@ -6417,15 +6493,26 @@
                 "crypto-random-string": "^2.0.0"
             }
         },
+        "universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha1-M4H4UDslHA2c0hvB3pOeyd9UgO4="
+        },
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
         },
+        "untildify": {
+            "version": "4.0.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/untildify/-/untildify-4.0.0.tgz",
+            "integrity": "sha1-K8lHuVNlJIfkYAlJ+wkeOujNkZs=",
+            "dev": true
+        },
         "update-notifier": {
-            "version": "4.1.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-4.1.0.tgz",
-            "integrity": "sha1-SGa5jDvFtUc8AgsSUFg2KPmjKPM=",
+            "version": "4.1.3",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/update-notifier/-/update-notifier-4.1.3.tgz",
+            "integrity": "sha1-vobuE+jOSPtQBD/3IFe1vVmOHqM=",
             "dev": true,
             "requires": {
                 "boxen": "^4.2.0",
@@ -6460,9 +6547,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+                    "version": "7.2.0",
+                    "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -6471,9 +6558,9 @@
             }
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+            "version": "4.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/uri-js/-/uri-js-4.4.0.tgz",
+            "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -6567,14 +6654,15 @@
             }
         },
         "whatwg-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-            "integrity": "sha1-/IBORYzEYACbGiuWa8iBfSV4rvs="
+            "version": "3.5.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+            "integrity": "sha1-YFos0KcUbl2xQeKdHGKrhMDEyGg="
         },
         "which": {
             "version": "1.3.1",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/which/-/which-1.3.1.tgz",
             "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -6636,14 +6724,6 @@
                 "string-width": "^4.0.0"
             }
         },
-        "windows-release": {
-            "version": "3.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/windows-release/-/windows-release-3.3.0.tgz",
-            "integrity": "sha1-3OFn6fi+cz8hyEnr1NA/5mspufA=",
-            "requires": {
-                "execa": "^1.0.0"
-            }
-        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -6688,9 +6768,9 @@
             }
         },
         "ws": {
-            "version": "7.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-7.3.0.tgz",
-            "integrity": "sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0="
+            "version": "7.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/ws/-/ws-7.4.0.tgz",
+            "integrity": "sha1-pd12okGXlA1Ki7ng4VK7RQN2Tac="
         },
         "xdg-basedir": {
             "version": "4.0.0",
@@ -6727,9 +6807,9 @@
             "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
         },
         "xmldom": {
-            "version": "0.3.0",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.3.0.tgz",
-            "integrity": "sha1-5iVFf0MAtd+cLh7Ld2FH7OR/Plo="
+            "version": "0.4.0",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/xmldom/-/xmldom-0.4.0.tgz",
+            "integrity": "sha1-h3HkgqMzr0RYfjDOAm8JmMI/ODA="
         },
         "xpath.js": {
             "version": "1.1.0",
@@ -6753,9 +6833,9 @@
             "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
         },
         "yargs": {
-            "version": "15.3.1",
-            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-15.3.1.tgz",
-            "integrity": "sha1-lQW0cnY5Y+VK/mAUitJ6MwgY6Ys=",
+            "version": "15.4.1",
+            "resolved": "https://botbuilder.myget.org/F/aitemplates/npm/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
             "dev": true,
             "requires": {
                 "cliui": "^6.0.0",
@@ -6768,7 +6848,7 @@
                 "string-width": "^4.2.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.1"
+                "yargs-parser": "^18.1.2"
             }
         },
         "yargs-parser": {

--- a/templates/typescript/samples/sample-assistant/package.json
+++ b/templates/typescript/samples/sample-assistant/package.json
@@ -34,10 +34,10 @@
     },
     "devDependencies": {
         "@types/restify": "^8.4.2",
-        "@typescript-eslint/eslint-plugin": "^2.0.0",
-        "@typescript-eslint/parser": "^2.0.0",
+        "@typescript-eslint/eslint-plugin": "^4.0.1",
+        "@typescript-eslint/parser": "^4.0.1",
         "copyfiles": "^2.1.0",
-        "eslint": "^5.16.0",
+        "eslint": "^6.1.0",
         "eslint-plugin-only-warn": "^1.0.1",
         "mocha": "^6.1.4",
         "mocha-junit-reporter": "^1.22.0",
@@ -45,7 +45,7 @@
         "nodemon": "^2.0.2",
         "nyc": "^14.1.1",
         "rimraf": "^2.6.2",
-        "typescript": "^3.2.2"
+        "typescript": "^4.0.5"
     },
     "env": {
         "mocha": true,

--- a/templates/typescript/samples/sample-assistant/src/dialogs/onboardingDialog.ts
+++ b/templates/typescript/samples/sample-assistant/src/dialogs/onboardingDialog.ts
@@ -13,7 +13,7 @@ import {
 import { IUserProfileState } from '../models/userProfileState';
 import { StateProperties } from '../models/stateProperties';
 import { BotServices } from '../services/botServices';
-import { LocaleTemplateManager, DialogContextEx } from 'bot-solutions';
+import { LocaleTemplateManager } from 'bot-solutions';
 import { LuisRecognizer } from 'botbuilder-ai';
 
 enum DialogIds {
@@ -53,7 +53,7 @@ export class OnboardingDialog extends ComponentDialog {
         }
         
         return await sc.prompt(DialogIds.NamePrompt, {
-                prompt: this.templateManager.generateActivityForLocale('NamePrompt', sc.context.activity.locale),
+            prompt: this.templateManager.generateActivityForLocale('NamePrompt', sc.context.activity.locale),
         });
     }
 


### PR DESCRIPTION
Related to 3652

### Purpose
*What is the context of this pull request? Why is it being done?*
A new version of TypeScript has been released (v4)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

- Updated TypeScript version to `^4.0.5` 
- Updated `p-queue` to `^6.0.0`
- Updated `eslint` to `^6.1.0`
- Updated `@typescript-eslint/eslint-plugin` to the version `^4.0.1`
- Updated `@typescript-eslint/parser` to the version `^4.0.1`
- Renamed rule `@typescript-eslint/no-object-literal-type-assertion` to `@typescript-eslint/no-use-before-define`
- Fixed ESLint issues
- Replicated changes to the VA Template

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
We manually tested the execution of the Virtual Assistant with TypeScript 4 and the execution of the unit tests.
![image](https://user-images.githubusercontent.com/20074735/99835725-c3a36280-2b43-11eb-9659-19e971a4c416.png)


### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
We are working on the implementation of TypeScript v4 in Skill

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
