### PR TITLE
[C#][Virtual Assistant Sample] Fixing inverted parameters in TokenExchangeSkillHandler.cs

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/TokenExchange/TokenExchangeSkillHandler.cs
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/TokenExchange/TokenExchangeSkillHandler.cs
@@ -114,8 +114,8 @@ namespace VirtualAssistantSample.TokenExchange
                                 // AAD token exchange
                                 var result = await _tokenExchangeProvider.ExchangeTokenAsync(
                                     context,
-                                    activity.Recipient?.Id,
                                     _tokenExchangeConfig.ConnectionName,
+                                    activity.Recipient?.Id,
                                     new TokenExchangeRequest() { Uri = oauthCard.TokenExchangeResource.Uri }).ConfigureAwait(false);
 
                                 if (!string.IsNullOrEmpty(result.Token))


### PR DESCRIPTION
Related to 3654 and 3655.

### Purpose
*What is the context of this pull request? Why is it being done?*

Parameters on `TokenExchangeSkillHandler.cs` need to be inverted since we need the ConnectionName before the Id following [IExtendedUserTokenProvider](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/OAuth/IExtendedUserTokenProvider.cs#L138)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
We updated the `TokenExchangeSkillHandler.cs` with the inverted parameters following the signature of `ExchangeTokenAsync`.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
\-

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
