### PR TITLE
[Documentation] Update /overview/virtual-assistant-template/ and fix broken links

### DIFF
--- a/docs/_docs/overview/virtual-assistant-template.md
+++ b/docs/_docs/overview/virtual-assistant-template.md
@@ -291,8 +291,27 @@ private async Task HandleTurnErrorAsync(ITurnContext turnContext, Exception exce
     _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
     await SendErrorMessageAsync(turnContext, exception);
-    await EndSkillConversationAsync(turnContext);
-    await ClearConversationStateAsync(turnContext);
+    ...    
+}
+
+private async Task SendErrorMessageAsync(ITurnContext turnContext, Exception exception)
+{
+    try
+    {
+        _telemetryClient.TrackException(exception);
+
+        // Send a message to the user.
+        await turnContext.SendActivityAsync(_templateEngine.GenerateActivityForLocale("ErrorMessage"));
+
+        // Send a trace activity, which will be displayed in the Bot Framework Emulator.
+        // Note: we return the entire exception in the value property to help the developer;
+        // this should not be done in production.
+        await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, $"Exception caught in SendErrorMessageAsync : {ex}");
+    }
 }
 ```
 

--- a/docs/_docs/overview/virtual-assistant-template.md
+++ b/docs/_docs/overview/virtual-assistant-template.md
@@ -36,7 +36,7 @@ To enable you to get started quickly, we have provided an ARM template and set o
 
 All of the steps provided by our scripts are documented [here]({{site.baseurl}}/virtual-assistant/tutorials/deploy-assistant/web/1-intro/) if you wish to review or perform manually.
 
-You can find the ARM template (template.json) in your **Deployment\Resources** folder or [here]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Resources). The PowerShell scripts can be found in your **Deployment\Scripts** folder or [here]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Template/VA/Deployment/Scripts).
+You can find the ARM template (template.json) in your **Deployment\Resources** folder or [here]({{site.repo}}/tree/master/templates/csharp/VA/VA/Deployment/Resources). The PowerShell scripts can be found in your **Deployment\Scripts** folder or [here]({{site.repo}}/tree/master/templates/csharp/VA/VA/Deployment/Scripts).
 
 ## Language
 
@@ -44,9 +44,14 @@ You can find the ARM template (template.json) in your **Deployment\Resources** f
 #### .lu file format
 {:.no_toc}
 
-The [LU](https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Ludown/docs/lu-file-format.md) format is similar to MarkDown enabling easy modification and source control of your LUIS models and QnA information. Virtual Assistant uses these files at its core to simplify deployment and provide an ongoing source control solution.
+The [LU](https://docs.microsoft.com/en-us/azure/bot-service/file-format/bot-builder-lu-file-format?view=azure-bot-service-4.0) format is similar to Markdown enabling easy modification and source control of your LUIS models and QnA information. Virtual Assistant uses these files at its core to simplify deployment and provide an ongoing source control solution.
 
-The [LuDown](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/Ludown) tool is then used to convert .LU files into LUIS models which can then be published to your LUIS subscription either through the portal or the associated [LUIS](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/LUIS) CLI (command line) tool. The same tool is used to create a QnA Maker JSON file which the [QnA Maker](https://github.com/Microsoft/botbuilder-tools/tree/master/packages/QnAMaker) CLI (command line) tool then uses to publish items to the QnA Maker knowledgebase.
+The [BF Command Line Interface](https://github.com/microsoft/botframework-cli) tool replaces the collection of standalone tools used to manage Bot Framework bots and related services.
+
+The [@microsoft/bf-luis-cli](https://github.com/microsoft/botframework-cli/blob/main/packages/luis/README.md) package contains the command [bf luis:convert](https://github.com/microsoft/botframework-cli/blob/main/packages/luis/README.md#bf-luisconvert) which converts .lu file(s) to a LUIS application JSON model or vice versa which can then be published to your LUIS subscription either through the portal or using [bf luis:application:publish](https://github.com/microsoft/botframework-cli/blob/main/packages/luis/README.md#bf-luisapplicationpublish).
+
+The [@microsoft/bf-qnamaker](https://github.com/microsoft/botframework-cli/blob/main/packages/qnamaker/README.md) package contains the command [bf qnamaker:convert](https://github.com/microsoft/botframework-cli/blob/main/packages/qnamaker/README.md#bf-qnamakerconvert) which converts .qna file(s) to QnA application JSON models or vice versa which can then be published using [bf qnamaker:kb:publish](https://github.com/microsoft/botframework-cli/blob/main/packages/qnamaker/README.md#bf-qnamakerkbpublish).
+
 
 All of the above is handled as part of the Deployment scripts detailed below.
 
@@ -56,18 +61,16 @@ All of the above is handled as part of the Deployment scripts detailed below.
 Every Bot should handle a base level of conversational language understanding. Cancellation or Help, for example, is a basic thing every Bot should handle with ease. Typically, developers need to create these base intents and provide initial training data to get started. The Virtual Assistant template provides example LU files to get you started and avoids every project having to create these each time and ensures a base level of capability out of the box.
 
 The LU files provide the following intents across English, Chinese, French, Italian, German, Spanish. 
-> Cancel, Confirm, Escalate, FinishTask, GoBack, Help, Reject, Repeat, SelectAny, SelectItem, SelectNone, ShowNext, ShowPrevious, StartOver, Stop
+> Cancel, Confirm, Escalate, ExtrackName, FinishTask, GoBack, Help, Logout, None, ReadAloud, Reject, Repeat, SelectAny, SelectItem, SelectNone, ShowNext, ShowPrevious, StartOver, Stop
 
-You can review these within the [**Deployment\Resources**]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/LU) directory.
+You can review these within the [**Deployment\Resources\LU**]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/LU) directory.
 
 ##### LUIS strongly-typed classes
 {:.no_toc}
 
-The [LuisGen](https://github.com/microsoft/botbuilder-tools/blob/master/packages/LUISGen/src/npm/readme.md) tool enables developers to create a strongly-typed class for their LUIS models. As a result, you can easily reference the intents and entities as class instance members.
+The [@microsoft/bf-luis-cli](https://github.com/microsoft/botframework-cli/blob/main/packages/luis/README.md) package contains the command [bf luis:generate:cs](https://github.com/microsoft/botframework-cli/tree/main/packages/luis#bf-luisgeneratecs) which generates a strongly types C# source code from an exported (json) LUIS model. As a result, you can easily reference the intents and entities as class instance members.
 
-You'll find a **GeneralLuis.cs** and **DispatchLuis.cs** class as part of your project within the [**Services**]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Services) folder. The DispatchLuis.cs will be re-generated if you add Skills to reflect the changes made.
-
-To learn more about LuisGen, see the [LuisGen Ttool](https://github.com/microsoft/botbuilder-tools/blob/master/packages/LUISGen/src/npm/readme.md) documentation.
+You'll find a **GeneralLuis.cs** and **DispatchLuis.cs** class as part of your project within the [**Services**]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Services) folder. The DispatchLuis.cs will be re-generated if you add Skills to reflect the changes made.
 
 #### QnA Maker
 {:.no_toc}
@@ -76,21 +79,21 @@ A key design pattern used to good effect in the first wave of conversational exp
 
 [QnA Maker](https://www.qnamaker.ai/) provides the ability for non-developers to curate general knowledge in the format of question and answer pairs. This knowledge can be imported from FAQ data sources, product manuals and interactively within the QnaMaker portal.
 
-Two example QnA Maker models localized to English, Chinese, French, Italian, German, Spanish are provided in the [LU](https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Ludown/docs/lu-file-format.md) file format within the **Deployment\Resources** folder or [here]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/QnA).
+Two example QnA Maker models localized to English, Chinese, French, Italian, German, Spanish are provided in the [LU](https://docs.microsoft.com/en-us/azure/bot-service/file-format/bot-builder-lu-file-format?view=azure-bot-service-4.0) file format within the **Deployment\Resources\QnA** folder or [here]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/QnA).
 
 ##### Base Personality
 {:.no_toc}
 
-QnAMaker provides 5 different personality types which you can find [here](https://github.com/microsoft/BotBuilder-PersonalityChat/tree/master/CSharp/Datasets). The Virtual Assistant template includes the **Professional** personality and has been converted into the [LU](https://github.com/Microsoft/botbuilder-tools/blob/master/packages/Ludown/docs/lu-file-format.md) format to ease source control and deployment.
+QnAMaker provides 5 different personality types which you can find [here](https://github.com/microsoft/BotBuilder-PersonalityChat/tree/master/CSharp/Datasets). The Virtual Assistant template includes the **Professional** personality and has been converted into the [LU](https://docs.microsoft.com/en-us/azure/bot-service/file-format/bot-builder-lu-file-format?view=azure-bot-service-4.0) file format to ease source control and deployment.
 
-You can review this within the [**Deployment\Resources**]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Deployment/Resources/QnA) directory.
+You can review this within the [**Deployment\Resources\QnA**]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/QnA) directory.
 
 ![QnA ChitChat example]({{site.baseurl}}/assets/images/qnachitchatexample.png)
 
 #### Dispatch Model
 {:.no_toc}
 
-[Dispatch](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-tutorial-dispatch?view=azure-bot-service-4.0&tabs=csaddref%2Ccsbotconfig) provides an elegant solution to bringing together LUIS models and QnAMaker knowledge-bases into one experience. It does this by extracting utterances from each configured LUIS model and questions from QnA Maker and creating a central dispatch LUIS model. This enables a Bot to quickly identify which LUIS model or component should handle a given utterance and ensures QnA Maker data is considered at the top level of intent processing not just through None intent processing as has been the case previously.
+[Dispatch](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-tutorial-dispatch?view=azure-bot-service-4.0&tabs=csaddref%2Ccsbotconfig) provides an elegant solution bringing together LUIS models and QnAMaker knowledge-bases into one experience. It does this by extracting utterances from each configured LUIS model and questions from QnA Maker and creating a central dispatch LUIS model. This enables a Bot to quickly identify which LUIS model or component should handle a given utterance and ensures QnA Maker data is considered at the top level of intent processing not just through None intent processing as has been the case previously.
 
 This Dispatch tool also enables model evaluation which will highlight confusion and overlap across LUIS models and QnA Maker knowledgebases highlighting issues before deployment.
 
@@ -112,15 +115,15 @@ To learn more about how multi-locale support is added, see the [localization doc
 
 ### Language generation and responses
 
-The Virtual Assistant has transitioned to use the new [Language Generation](https://github.com/Microsoft/BotBuilder-Samples/tree/master/experimental/language-generation#readme) capability to provide a more natural conversational experience by being able to define multiple response variations and leverage context/memory to adapt these dynamically to end-users.
+The Virtual Assistant has transitioned to use the new [Language Generation](https://github.com/Microsoft/BotBuilder-Samples/tree/main/experimental/language-generation#readme) capability to provide a more natural conversational experience by being able to define multiple response variations and leverage context/memory to adapt these dynamically to end-users.
 
-Language Generation (LG) leverages a new [LG file format](https://github.com/microsoft/BotBuilder-Samples/blob/master/experimental/language-generation/docs/lg-file-format.md) which follows the same markdown approach as the LU file format mentioned earlier. This enables easy editing of responses by a broad range of roles.
+Language Generation (LG) leverages a new [LG file format](https://docs.microsoft.com/en-us/azure/bot-service/file-format/bot-builder-lg-file-format?view=azure-bot-service-4.0) which follows the same Markdown approach as the LU file format mentioned earlier. This enables easy editing of responses by a broad range of roles.
 
 LG also enables Adaptive Card responses to be defined alongside responses further simplifying management and localization of responses.
 
-LG files for your Virtual Assistant can be found in your **responses** folder or [here]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Responses) and the Template Engine code can be found in your **Startup.cs** file.
+LG files for your Virtual Assistant can be found in your **responses** folder or [here]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Responses) and the Template Engine code can be found in your **Startup.cs** file.
 
-An example of LG in use can be found [here]({{site.repo}}/blob/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs#L77) and throughout the Virtual Assistant.
+An example of LG in use can be found [here]({{site.repo}}/blob/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs#L244) and throughout the Virtual Assistant.
 
 ## Dialogs
 
@@ -129,7 +132,7 @@ Beyond the core **MainDialog** dialog two further dialogs are provided firstly t
 ### Main Dialog
 {:.no_toc}
 
-The [**MainDialog**]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs) class as discussed earlier in this section is the core part of the Activity processing stack and is where all activities are processed. This is also where the Help intent is handled which returns a response as defined within the Language Generation responses. Events are also handled as part of this dialog.
+The [**MainDialog**]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs) class as discussed earlier in this section is the core part of the Activity processing stack and is where all activities are processed. This is also where the Help intent is handled which returns a response as defined within the Language Generation responses. Events are also handled as part of this dialog.
 
 #### Introduction card
 
@@ -142,24 +145,19 @@ A simple introduction card is provided as standard which you can adapt as needed
 ### Onboarding Dialog
 {:.no_toc}
 
-The [**OnboardingDialog**]({{site.repo}}/blob/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/OnboardingDialog.cs) provides an example introduction Dialog experience for users starting their first conversation. It prompts for some information which is then stored in State for future use by your assistant. This dialog demonstrates how you can use prompts and state.
-
-### Escalate Dialog
-{:.no_toc}
-
-The [**EscalateDialog**]({{site.repo}}/blob/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/EscalateDialog.cs) demonstrates a stubbed dialog to handle a user asking to be transferred to a human. This is where you could integrate to a human-handoff capability. The provided implementation returns a response with a placeholder telephone number.
+The [**OnboardingDialog**]({{site.repo}}/blob/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/OnboardingDialog.cs) provides an example introduction Dialog experience for users starting their first conversation. It prompts for some information which is then stored in State for future use by your assistant. This dialog demonstrates how you can use prompts and state.
 
 ## Managing state
 
-CosmosDB is used as the default state store through the SDK provided `CosmosDbStorage` storage provider. This provides a production-grade, scalable storage layer for your Bots state along with fast disaster recovery capabilities and regional replication where required. Features like automatic time-to-live provide additional benefits around clean-up of old conversations.
+CosmosDB is used as the default state store through the SDK provided `CosmosDbPartitionedStorage` storage provider. This provides a production-grade, scalable storage layer for your Bots state along with fast disaster recovery capabilities and regional replication where required. Features like automatic time-to-live provide additional benefits around clean-up of old conversations.
 
-Within **Startup.cs** you can optionally choose to disable use of CosmosDB and switch to MemoryStorage often used for development operations but ensure this is reverted ahead of production deployment.
+Within **Startup.cs** you can optionally choose to disable use of CosmosDbPartitionedStorage and switch to MemoryStorage often used for development operations but ensure this is reverted ahead of production deployment.
 
 ```csharp
  // Configure storage
  // Uncomment the following line for local development without Cosmos Db
  // services.AddSingleton<IStorage, MemoryStorage>();
- services.AddSingleton<IStorage>(new CosmosDbStorage(settings.CosmosDb));
+ services.AddSingleton<IStorage>(new CosmosDbPartitionedStorage(settings.CosmosDb));
 ```
 
 Deployment can be customized to omit deployment of CosmosDB and is covered in the [deployment documentation]({{site.baseurl}}/virtual-assistant/handbook/deployment-scripts/).
@@ -168,17 +166,17 @@ Deployment can be customized to omit deployment of CosmosDB and is covered in th
 ### Activity processing
 {:.no_toc}
 
-1. Activities are first processed within your Bot through the DialogBot.cs class found in the **Bots** folder. **OnTurnAsync** is executed and **MainDialog** processing is started.
+1. Activities are first processed within your Bot through the DefaultActivityHandler.cs class found in the **Bots** folder. **OnTurnAsync** is executed and **MainDialog** processing is started.
 
-1. The **MainDialog** dialog provided in the template derives from a base class called [RouterDialog]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs) which can be found in the  **Microsoft.Bot.Builder.Solutions** NuGet library.
+1. The **MainDialog** dialog provided in the template derives from a base class called [ComponentDialog](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs) which can be found in the  **Microsoft.Bot.Builder.Dialogs** NuGet library.
 
-1. The **OnInterruptDialogAsync** handler within **MainDialog** is executed which in-turn calls LUIS to evaluate the **General** LUIS model for top intent processing. If interruption is required it's processed at this point.
+1. The **InterruptDialogAsync** handler within **MainDialog** is executed which in-turn calls LUIS to evaluate the **General** LUIS model for top intent processing. If interruption is required it's processed at this point.
 
-1. Processing returns back to RouterDialog which will end the dialog if interruption has been requested.
+1. Processing returns back to ComponentDialog which will end the dialog if interruption has been requested.
 
-1. If the Activity is a message and there is an active dialog, the activity is forwarded on. If there is no Active dialog then RouteAsync on MainDialog is invoked to perform "Turn 0" processing.
+1. If the Activity is a message and there is an active dialog, the activity is forwarded on. If there is no Active dialog then RouteStepAsync on MainDialog is invoked to perform "Turn 0" processing.
 
-1. **RouteAsync** within MainDialog invokes the Dispatch model to identify whether it should hand the utterance to:
+1. **RouteStepAsync** within MainDialog invokes the Dispatch model to identify whether it should hand the utterance to:
     - A dialog (mapped to a LUIS intent)
     - QnAMaker (Chitchat or QnA)
     - A Skill (mapped to a Dispatcher skill intent)
@@ -188,21 +186,21 @@ Deployment can be customized to omit deployment of CosmosDB and is covered in th
 
 Middleware is simply a class that sits between the adapter and your bot logic, added to your adapter's middleware collection during initialization. Every activity coming into or out of your Assistant flows through your middleware.
 
-A number of middleware components have been provided to address some key scenarios and are included in the **Microsoft.Bot.Builder.Solutions** nuget library or in [this location]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware).
+A number of middleware components have been provided to address some key scenarios and are included in the **Microsoft.Bot.Solutions** NuGet library or in [this location]({{site.repo}}/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Middleware).
 
 #### Set Locale Middleware
 {:.no_toc}
 
 In multi-locale scenarios, it's key to understand the user's locale so you can select the appropriate language LUIS Models and responses for a given user. Most channels populate the **Locale** property on an incoming Message activity but there are many cases where this may not be present thus it's important to stamp a default locale on activities where this is missing so downstream components 
 
-You can find this component within the **Microsoft.Bot.Builder.Solutions** NuGet library or in [this location]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/SetLocaleMiddleware.cs).
+You can find this component within the **Microsoft.Bot.Solutions** NuGet library or in [this location]({{site.repo}}/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetLocaleMiddleware.cs).
 
 #### Set Speak Middleware
 {:.no_toc}
 
 For Speech scenario's providing a fully formed SSML fragment is required in order to be able to control the voice, tone and more advanced capabilities such as pronunciation. Setting the **Speak** property on the Activity to a Speech representation should be performed as part of the Language Generation step but in cases where this is omitted we can transpose the Activity.Text property into Speak to ensure all responses have Speech variations.
 
-The [**Set Speak Middleware**]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/SetSpeakMiddleware.cs) provides these capabilities and only executes when the Direct-Line Speech channel is used.  An example SSML fragment is shown below:
+The [**Set Speak Middleware**]({{site.repo}}/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/SetSpeakMiddleware.cs) provides these capabilities and only executes when the Direct-Line Speech channel is used.  An example SSML fragment is shown below:
 
 ```json
 <speak version='1.0' xmlns="https://www.w3.org/2001/10/synthesis" xmlns:mstts="https://www.w3.org/2001/mstts" xml:lang="en-US">
@@ -215,14 +213,14 @@ You have the following event on your calendar: Sync Meeting at 4PM with 2 people
 #### Console Output Middleware
 {:.no_toc}
 
-The [**Console Output Middleware**]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/ConsoleOutputMiddleware.cs) is a simple component for debugging that outputs incoming and outcoming activities to the console enabling you to easily see the Text/Speak responses flowing through your Bot.
+The [**Console Output Middleware**]({{site.repo}}/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/ConsoleOutputMiddleware.cs) is a simple component for debugging that outputs incoming and outcoming activities to the console enabling you to easily see the Text/Speak responses flowing through your Bot.
 
 #### Event Debugger Middleware
 {:.no_toc}
 
 Event Activities can be used to pass metadata between an assistant and user without being visible to the user. These events can enable a device or application to communicate an event to an assistant (e.g. being switched on) or enable an assistant to convey an action to a device to perform such as opening a deep link to an application or changing the temperature.
 
-It can be hard to generate these activities for testing purposes as the Bot Framework Emulator doesn't provide the ability to send Activities. The [**Event Debug Middleware**]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/EventDebuggerMiddleware.cs) provides an elegant workaround enabling you to send messages following a specific format which are then transposed into an Event activity processed by your Assistant
+It can be hard to generate these activities for testing purposes as the Bot Framework Emulator doesn't provide the ability to send Activities. The [**Event Debugger Middleware**]({{site.repo}}/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/EventDebuggerMiddleware.cs) provides an elegant workaround enabling you to send messages following a specific format which are then transposed into an Event activity processed by your Assistant
 
 For example sending this message with the middleware registered: **/event:{ "Name": "{Event name}", "Value": "{Event value}" }** would generate an Activity of type event being created with the appropriate Value.
 
@@ -231,7 +229,7 @@ For example sending this message with the middleware registered: **/event:{ "Nam
 
 Content Moderator is an optional component that enables the detection of potential profanity and helps check for personally identifiable information (PII). This can be helpful to integrate into Bots enabling a Bot to react to profanity or if the user shares PII information. For example, a Bot can apologize and hand-off to a human or not store telemetry records if PII information is detected.
 
-[**Content Moderator Middleware**]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Middleware/ContentModeratorMiddleware.cs)  is provided that screen texts and surfaces output through a **TextModeratorResult** on the **TurnState** object. This middleware is not enabled by default.
+[**Content Moderator Middleware**]({{site.repo}}/blob/master/sdk/csharp/libraries/microsoft.bot.solutions/Middleware/ContentModeratorMiddleware.cs) is provided that screen texts and surfaces output through a **TextModeratorResult** on the **TurnState** object. This middleware is not enabled by default.
 
 In order to enable this you need to provision the Content Moderator Azure resource. Once created, make note of the key and endpoint provided. In the DefaultAdapter.cs class, add a new line Use(new ContentModeratorMiddleware({KEY}, {REGION})) to the list of enabled middleware.
 
@@ -240,30 +238,20 @@ In order to enable this you need to provision the Content Moderator Azure resour
 
 Collecting feedback from users at the end of an interaction is a great way to measure how your assistant is doing with resolving end-users objectives beyond in addition to measuring dialog completion metrics. Forcing the user to complete feedback is highly disruptive to an overall experience so it's important to make this optional and not get in the way of the user.
 
-The [**Feedback Middleware**]() provides a way to collect feedback leveraging suggested actions thus making the request optional and surfaces simple 👍 and 👎 options with an option to provide a text response too. This feedback is then stored through the usual Application Insights telemetry storage and surfaced via the accompanying PowerBI dashboard.
+The **Feedback Middleware** provides a way to collect feedback leveraging suggested actions thus making the request optional and surfaces simple 👍 and 👎 options with an option to provide a text response too. This feedback is then stored through the usual Application Insights telemetry storage and surfaced via the accompanying PowerBI dashboard.
 
 By default, the middleware activates at the end of every dialog but you can customize this further to suit your scenario, for example only asking for feedback when LUIS or QnA prediction scores are low or perhaps at random or a limited number of times in a time period.
 
 To learn more about the Feedback capability, see the [Feedback documentation]({{site.baseurl}}/virtual-assistant/handbook/feedback/).
 
-
 ### Interruptions
 {:.no_toc}
 
-The **MainDialog** class provided in the template derives from a base class called [RouterDialog]({{site.repo}}/blob/master/lib/csharp/microsoft.bot.builder.solutions/microsoft.bot.builder.solutions/Dialogs/RouterDialog.cs) which can be found in the  **Microsoft.Bot.Builder.Solutions** NuGet library.
+The **MainDialog** class provided in the template derives from a base class called [ComponentDialog](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs) which can be found in the  **Microsoft.Bot.Builder.Dialogs** NuGet library.
 
-This RouterDialog as part of the **OnContinueDialogAsync** handler invokes on the **OnInterruptDialogAsync** within your **MainDialog.cs**. This handler enables interruption logic to be processed before any utterance is processed, by default Cancel, Help, Logout and Restart are handled as part of this handler enabling top-level intent processing even when you have an active dialog.
+This MainDialog as part of the **OnContinueDialogAsync** handler invokes on the **InterruptDialogAsync**. This handler enables interruption logic to be processed before any utterance is processed, by default Cancel, Escalate, Help, Logout, Repeat, StartOver, Stop are handled as part of this handler enabling top-level intent processing even when you have an active dialog.
 
-You can review this logic within [**MainDialog.cs**]({{site.repo}}/blob/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs#L295).
-
-### Event processing
-{:.no_toc}
-
-Events play a central role to an assistant experience and we provide a central event handler as part of the **MainDialog** implementation. **OnEventAsync** provides support for two key events: **VA.Location** and **VA.Timezone**. These events are processed, validated and then stored in state enabling dialogs and Skills to leverage these as required to enable them to adapt to the user. For example, the Point of Interest skill can decide not to prompt for your current location if a Location is present.
-
-In addition, the standard **token/response** event is handled as per the Azure Bot Service authentication feature.
-
-This event handler can be extended as required to support your specific scenarios. You can find this in [**MainDialog.cs**]({{site.repo}}/blob/master_docs/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample/Dialogs/MainDialog.cs#L208).
+You can review this logic within [**MainDialog.cs**]({{site.repo}}/blob/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Dialogs/MainDialog.cs#L201).
 
 ### Fallback responses
 {:.no_toc}
@@ -278,14 +266,36 @@ Whilst exceptions are typically handled at source it's important to have a globa
 The provided Exception handler passes information on the Exception as a Trace activity enabling it to be shown within the Bot Framework Emulator if it's being used otherwise these are suppressed. A general Error message is then shown to the user and the exception is logged through Application Insights.
 
 ```csharp
-OnTurnError = async (turnContext, exception) =>
+public DefaultAdapter(
+    BotSettings settings,
+    ICredentialProvider credentialProvider,
+    IChannelProvider channelProvider,
+    AuthenticationConfiguration authConfig,
+    LocaleTemplateManager templateEngine,
+    ConversationState conversationState,
+    TelemetryInitializerMiddleware telemetryMiddleware,
+    IBotTelemetryClient telemetryClient,
+    ILogger<BotFrameworkHttpAdapter> logger,
+    SkillsConfiguration skillsConfig = null,
+    SkillHttpClient skillClient = null)
+    : base(credentialProvider, authConfig, channelProvider, logger: logger)
 {
-    await turnContext.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"{exception.Message}"));
-    await turnContext.SendActivityAsync(new Activity(type: ActivityTypes.Trace, text: $"{exception.StackTrace}"));
-    await turnContext.SendActivityAsync(MainStrings.ERROR);
-    telemetryClient.TrackException(exception);
-};
+    ...
+    OnTurnError = HandleTurnErrorAsync;
+    ...
+}
+
+private async Task HandleTurnErrorAsync(ITurnContext turnContext, Exception exception)
+{
+    // Log any leaked exception from the application.
+    _logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+    await SendErrorMessageAsync(turnContext, exception);
+    await EndSkillConversationAsync(turnContext);
+    await ClearConversationStateAsync(turnContext);
+}
 ```
+
 ## Skill support 
 
 The Virtual Assistant integrates Skill support for your assistant, enabling you to easily register skills through the execution of the `botskills` command-line tool. The ability to trigger skills based on utterances relies heavily on the Dispatcher which is automatically provisioned as part of your assistant deployment.
@@ -325,7 +335,7 @@ To learn more about Telemetry, see the [Analytics tutorial]({{site.baseurl}}/sol
 
 Unit testing of dialogs is an important capability for any project. A number of examples unit tests are provided as part of the Virtual Assistant and cover all capabilities provided. These can be used as a baseline to build your own additional tests.
 
-You can find these tests in a companion project to your assistant or [here]({{site.repo}}/tree/master/templates/Virtual-Assistant-Template/csharp/Sample/VirtualAssistantSample.Tests).
+You can find these tests in a companion project to your assistant or [here]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.Tests).
 
 
 ## Continuous integration and deployment
@@ -333,4 +343,3 @@ You can find these tests in a companion project to your assistant or [here]({{si
 A [Azure DevOps](https://azure.microsoft.com/en-us/solutions/devops/) [YAML](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema) file for Continuous Integration is included within the `pipeline` folder of your assistant and provides all the steps required to build your assistant project and generate code coverage results. This can be imported into your Azure DevOps environment to create a build.
 
 In addition, documentation to create a [release pipeline]({{site.baseurl}}/solution-accelerators/tutorials/enable-continuous-deployment/1-intro/) is also provided enabling you to continuously deploy updates to your project to your Azure test environment and also update Dispatch, LUIS and QnAMaker resources with any changes to the LU files within source control.
-

--- a/docs/_docs/overview/virtual-assistant-template.md
+++ b/docs/_docs/overview/virtual-assistant-template.md
@@ -61,7 +61,7 @@ All of the above is handled as part of the Deployment scripts detailed below.
 Every Bot should handle a base level of conversational language understanding. Cancellation or Help, for example, is a basic thing every Bot should handle with ease. Typically, developers need to create these base intents and provide initial training data to get started. The Virtual Assistant template provides example LU files to get you started and avoids every project having to create these each time and ensures a base level of capability out of the box.
 
 The LU files provide the following intents across English, Chinese, French, Italian, German, Spanish. 
-> Cancel, Confirm, Escalate, ExtrackName, FinishTask, GoBack, Help, Logout, None, ReadAloud, Reject, Repeat, SelectAny, SelectItem, SelectNone, ShowNext, ShowPrevious, StartOver, Stop
+> Cancel, Confirm, Escalate, ExtractName, FinishTask, GoBack, Help, Logout, None, ReadAloud, Reject, Repeat, SelectAny, SelectItem, SelectNone, ShowNext, ShowPrevious, StartOver, Stop
 
 You can review these within the [**Deployment\Resources\LU**]({{site.repo}}/tree/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Deployment/Resources/LU) directory.
 


### PR DESCRIPTION
Solve 3672

### Purpose
*What is the context of this pull request? Why is it being done?*
The [/overview/virtual-assistant-template/](https://microsoft.github.io/botframework-solutions/overview/virtual-assistant-template/) has broken links and is outdated.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Fix broken links
- Update documentation with the new version of the Virtual Assistant Template/Sample

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

![image](https://user-images.githubusercontent.com/11904023/95482776-dcc1cc80-0964-11eb-867c-d5f82c952219.png)

![image](https://user-images.githubusercontent.com/11904023/95483056-27dbdf80-0965-11eb-8791-c42025d806b2.png)

![image](https://user-images.githubusercontent.com/11904023/95484044-5c9c6680-0966-11eb-8c69-6758cfacc3ed.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [X] I have updated related documentation
