### PR TITLE
[C#][VSIX] Fix template placeholder not correctly replaced in Skill yml file

### DIFF
--- a/templates/csharp/Skill/Skill/SkillProjectTemplate.vstemplate
+++ b/templates/csharp/Skill/Skill/SkillProjectTemplate.vstemplate
@@ -94,7 +94,7 @@
         <ProjectItem ReplaceParameters="true" TargetFileName="StateProperties.cs">StateProperties.cs</ProjectItem>
       </Folder>
       <Folder Name="Pipeline" TargetFolderName="Pipeline">
-        <ProjectItem ReplaceParameters="false" TargetFileName="$safeprojectname$.yml">SkillSample.yml</ProjectItem>
+        <ProjectItem ReplaceParameters="true" TargetFileName="$safeprojectname$.yml">SkillSample.yml</ProjectItem>
       </Folder>
       <Folder Name="Responses" TargetFolderName="Responses">
         <ProjectItem ReplaceParameters="false" TargetFileName="AllResponses.lg">AllResponses.lg</ProjectItem>


### PR DESCRIPTION
Fix 3673

### Purpose
*What is the context of this pull request? Why is it being done?*

The `$safeprojectname$` variable is not replaced correctly in the _[SkillSample].yml_ file of the Pipeline Folder when a Skill project is created using the VSIX.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

We made a change in the file `SkillProjectTemplate.vstemplate`. In the section **Folder Name Pipeline**, configured the parameter `ReplaceParameters` in true.

### Tests

![image](https://user-images.githubusercontent.com/51216149/95492965-311f7900-0972-11eb-8c03-efa3fccf89d9.png)

![image](https://user-images.githubusercontent.com/51216149/95493247-95423d00-0972-11eb-9973-eb406ede417d.png)

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
