### PR TITLE
[botskills] Fix luFilePath join 

### DIFF
--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -108,7 +108,8 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
                 }
 
                 if (luFile.trim.length === 0) {
-                    luFile = parse(luFilePath).name + '.luis';
+                    luFile = parse(luFilePath).name;
+                    luisFile = luFile + '.luis';
                 }
                 luisFilePath = join(luisFolderPath, luisFile);
             }

--- a/tools/botskills/src/functionality/connectSkill.ts
+++ b/tools/botskills/src/functionality/connectSkill.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { join , parse} from 'path';
 import { get } from 'request-promise-native';
 import { ConsoleLogger, ILogger } from '../logger';
 import {
@@ -108,8 +108,7 @@ Remember to use the argument '--dispatchFolder' for your Assistant's Dispatch fo
                 }
 
                 if (luFile.trim.length === 0) {
-                    luFile = luFilePath.split('\\').reverse()[0];
-                    luisFile = `${ luFile.toLowerCase() }is`;
+                    luFile = parse(luFilePath).name + '.luis';
                 }
                 luisFilePath = join(luisFolderPath, luisFile);
             }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Unix OS doesn't use `\` on the directory paths, instead it uses `/`, so while trying to join the `luFilePath` on the `connect` command of botskills, the path can't be splited for this reason.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

Instead of spliting the path now it is being parsed to be accepted in others OS.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
*-*
### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
*-*
### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
