### PR TITLE
[C#][Bot-Solutions] Ignore NU5048 warning

### DIFF
--- a/sdk/csharp/Directory.Build.props
+++ b/sdk/csharp/Directory.Build.props
@@ -53,6 +53,6 @@
       Suppress a warning about upcoming deprecation of PackageLicenseUrl. When embedding licenses are supported,
       replace PackageLicenseUrl with PackageLicenseExpression.
     -->
-    <NoWarn>$(NoWarn);NU5125;NU1701;8002</NoWarn>
+    <NoWarn>$(NoWarn);NU5125;NU1701;8002;NU5048</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
The [NU5048](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5048) stops the compilation of C# Bot-Solutions in Azure Pipeline.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
Skip `NU5048` warning during compilation

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Yes, it was tested manually and in a pipeline

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
This solution is the short-term workaround, however, the long-term approach will be to follow the [Dotnet SDK](https://github.com/microsoft/botbuilder-dotnet/blob/main/Directory.Build.props#L61) specifying `PackageIcon` and `PackageIconUrl` to maintain [backward compatibility](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packageiconurl).

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
