### PR TITLE
[TypeScript][Bot-Solutions] Add the missing parameter outhCredentials in getTokenStatus method in multiProviderAuthDialog class

### DIFF
--- a/sdk/typescript/libraries/bot-solutions/src/authentication/multiProviderAuthDialog.ts
+++ b/sdk/typescript/libraries/bot-solutions/src/authentication/multiProviderAuthDialog.ts
@@ -121,7 +121,9 @@ export class MultiProviderAuthDialog extends ComponentDialog {
         if (adapter !== undefined) {
             const tokenStatusCollection: TokenStatus[] = await adapter.getTokenStatus(
                 stepContext.context,
-                stepContext.context.activity.from.id);
+                stepContext.context.activity.from.id,
+                undefined,
+                this.oauthCredentials);
 
             const matchingProviders: TokenStatus[] = tokenStatusCollection.filter((p: TokenStatus): boolean => {
                 return (p.hasToken || false) && this.authenticationConnections.some((t: IOAuthConnection): boolean => {
@@ -232,7 +234,7 @@ export class MultiProviderAuthDialog extends ComponentDialog {
         //PENDING: adapter could not be parsed to IExtendedUserTokenProvider as C# does
         const tokenProvider: BotFrameworkAdapter = context.adapter as BotFrameworkAdapter;
         if (tokenProvider !== undefined) {
-            return await tokenProvider.getTokenStatus(context, userId, includeFilter);
+            return await tokenProvider.getTokenStatus(context, userId, includeFilter, this.oauthCredentials);
         } else {
             throw new Error('Adapter does not support IExtendedUserTokenProvider');
         }

--- a/sdk/typescript/libraries/bot-solutions/src/botSettingsBase.ts
+++ b/sdk/typescript/libraries/bot-solutions/src/botSettingsBase.ts
@@ -137,14 +137,14 @@ export interface CognitiveModelConfiguration {
 
 export interface OAuthCredentialsConfiguration {
     /**
-     * Gets or sets the collection of LUIS models.
-     * The collection of LUIS models.
+     * Gets or sets the Microsoft App Id for OAuth.
+     * The microsoft app id for OAuth.
      */
     microsoftAppId: string;
 
     /**
-     * Gets or sets the collection of LUIS models.
-     * The collection of LUIS models.
+     * Gets or sets the Microsoft App Password for OAuth.
+     * The microsoft app password for OAuth.
      */
     microsoftAppPassword: string;
 }


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
Fix disparity between C# and TS implementation

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Add the missing parameter `outhCredentials` in the `getTokenStatus` method in the `multiProviderAuthDialog` class

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
All unit tests passed successfully

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
