### PR TITLE
[Functional Tests] Remove the dotnet restore steps

### DIFF
--- a/templates/typescript/samples/sample-skill/functional-tests/sample-skill.yml
+++ b/templates/typescript/samples/sample-skill/functional-tests/sample-skill.yml
@@ -115,13 +115,6 @@ jobs:
     failOnStderr: true
 
   - task: DotNetCoreCLI@2
-    displayName: 'Test: Run dotnet restore'
-    inputs:
-      command: restore
-      projects: 'templates/typescript/samples/sample-skill/functional-tests/SkillSample.FunctionalTests/SkillSample.FunctionalTests.csproj'
-
-
-  - task: DotNetCoreCLI@2
     displayName: 'Test: Run dotnet build'
     inputs:
       projects: 'templates/typescript/samples/sample-skill/functional-tests/SkillSample.FunctionalTests/SkillSample.FunctionalTests.csproj'

--- a/tools/botskills/botskills.functionalTest/nightly-botskills.yml
+++ b/tools/botskills/botskills.functionalTest/nightly-botskills.yml
@@ -123,25 +123,11 @@ jobs:
        **/wwwroot/manifest/manifest-1.1.json
 
   - task: DotNetCoreCLI@2
-    displayName: 'Prepare: VA - Restore dependencies'
-    inputs:
-      command: restore
-      projects: 'samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.sln'
-      restoreDirectory: 'samples/csharp/assistants/virtual-assistant/'
-
-  - task: DotNetCoreCLI@2
     displayName: 'Prepare: VA - Build project'
     inputs:
       projects: 'samples/csharp/assistants/virtual-assistant/VirtualAssistantSample.sln'
       arguments: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="$(build.artifactstagingdirectory)\WebApp.zip" /p:DeployIisAppPath="Default Web Site" /property:langversion=latest'
       workingDirectory: 'samples/csharp/assistants/virtual-assistant/'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Prepare: Skill - Restore dependencies'
-    inputs:
-      command: restore
-      projects: samples/csharp/skill/SkillSample.sln
-      restoreDirectory: samples/csharp/skill/
 
   - task: DotNetCoreCLI@2
     displayName: 'Prepare: Skill - Build project'

--- a/yaml/dotnetBuildSteps.yml
+++ b/yaml/dotnetBuildSteps.yml
@@ -1,13 +1,5 @@
 # Restores, builds and runs unit tests
 
-steps:
-  - task: DotNetCoreCLI@2
-    displayName: 'Dotnet Restore'
-    inputs:
-      command: restore
-      projects: $(SolutionPath)$(SolutionName)
-      restoreDirectory: $(SolutionPath)
-
   - task: DotNetCoreCLI@2
     displayName: 'Dotnet Build'
     inputs:


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
The dotnet restore step is not necessary since dotnet build step already does it

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Remove the dotnet restore step from all the yaml files

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
