### PR TITLE
Fix MultiProviderAuthDialog not being localized

### DIFF
--- a/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Solutions.Authentication
     /// </summary>
     public class MultiProviderAuthDialog : ComponentDialog
     {
-        private static readonly string[] _acceptedLocales = new string[] { "en", "de", "es", "fr", "it", "zh" };
+        private static readonly string[] acceptedLocales = new string[] { "en", "de", "es", "fr", "it", "zh" };
         private string _selectedAuthType = string.Empty;
         private List<OAuthConnection> _authenticationConnections;
         private ResponseManager _responseManager;

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Bot.Solutions.Authentication
     /// </summary>
     public class MultiProviderAuthDialog : ComponentDialog
     {
+        private static readonly string[] _acceptedLocales = new string[] { "en", "de", "es", "fr", "it", "zh" };
         private string _selectedAuthType = string.Empty;
         private List<OAuthConnection> _authenticationConnections;
         private ResponseManager _responseManager;
@@ -37,7 +38,7 @@ namespace Microsoft.Bot.Solutions.Authentication
             _authenticationConnections = authenticationConnections ?? throw new ArgumentNullException(nameof(authenticationConnections));
             _oauthCredentials = oauthCredentials;
             _responseManager = new ResponseManager(
-                new string[] { "en", "de", "es", "fr", "it", "zh" },
+                _acceptedLocales,
                 new AuthenticationResponses());
 
             var firstStep = new WaterfallStep[]
@@ -62,23 +63,13 @@ namespace Microsoft.Bot.Solutions.Authentication
                 {
                     var connection = _authenticationConnections[i];
 
-                    // We ignore placeholder connections in config that don't have a Name
-                    if (!string.IsNullOrWhiteSpace(connection.Name))
+                    foreach (var locale in _acceptedLocales)
                     {
-                        var loginButtonActivity = _responseManager.GetResponse(AuthenticationResponses.LoginButton);
-                        var loginPromptActivity = _responseManager.GetResponse(AuthenticationResponses.LoginPrompt, new StringDictionary() { { "authType", connection.Name } });
-                        var settings = promptSettings?[i] ?? new OAuthPromptSettings
+                        // We ignore placeholder connections in config that don't have a Name
+                        if (!string.IsNullOrWhiteSpace(connection.Name))
                         {
-                            ConnectionName = connection.Name,
-                            Title = loginButtonActivity.Text,
-                            Text = loginPromptActivity.Text,
-                        };
-                        settings.OAuthAppCredentials = _oauthCredentials;
-
-                        AddDialog(new OAuthPrompt(
-                            connection.Name,
-                            settings,
-                            AuthPromptValidatorAsync));
+                            AddDialog(GetLocalizedDialog(locale, connection.Name, promptSettings?[i]));
+                        }
                     }
                 }
 
@@ -114,7 +105,7 @@ namespace Microsoft.Bot.Solutions.Authentication
         {
             if (_authenticationConnections.Count == 1)
             {
-                var result = _authenticationConnections.First().Name;
+                var result = _authenticationConnections.First().Name + "_" + CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
                 return await stepContext.NextAsync(result).ConfigureAwait(false);
             }
 
@@ -254,6 +245,24 @@ namespace Microsoft.Bot.Solutions.Authentication
 
             TelemetryClient.TrackEvent("AuthPromptValidatorAsyncFailure");
             return Task.FromResult(false);
+        }
+
+        private OAuthPrompt GetLocalizedDialog(string locale, string connectionName, OAuthPromptSettings settings)
+        {
+            var loginButtonActivity = _responseManager.GetResponse(AuthenticationResponses.LoginButton, locale);
+            var loginPromptActivity = _responseManager.GetResponse(AuthenticationResponses.LoginPrompt, locale, new StringDictionary() { { "authType", connectionName } });
+            settings = settings ?? new OAuthPromptSettings
+            {
+                ConnectionName = connectionName,
+                Title = loginButtonActivity.Text,
+                Text = loginPromptActivity.Text,
+            };
+            settings.OAuthAppCredentials = _oauthCredentials;
+
+            return new OAuthPrompt(
+                connectionName + "_" + locale,
+                settings,
+                AuthPromptValidatorAsync);
         }
 
         private static class DialogIds

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Solutions.Authentication
                 {
                     var connection = _authenticationConnections[i];
 
-                    foreach (var locale in _acceptedLocales)
+                    foreach (var locale in acceptedLocales)
                     {
                         // We ignore placeholder connections in config that don't have a Name
                         if (!string.IsNullOrWhiteSpace(connection.Name))

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Authentication/MultiProviderAuthDialog.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Solutions.Authentication
             _authenticationConnections = authenticationConnections ?? throw new ArgumentNullException(nameof(authenticationConnections));
             _oauthCredentials = oauthCredentials;
             _responseManager = new ResponseManager(
-                _acceptedLocales,
+                acceptedLocales,
                 new AuthenticationResponses());
 
             var firstStep = new WaterfallStep[]

--- a/sdk/csharp/libraries/microsoft.bot.solutions/Responses/ResponseManager.cs
+++ b/sdk/csharp/libraries/microsoft.bot.solutions/Responses/ResponseManager.cs
@@ -69,6 +69,24 @@ namespace Microsoft.Bot.Solutions.Responses
         }
 
         /// <summary>
+        /// Gets a simple response from template with Text, Speak, InputHint, and SuggestedActions set.
+        /// </summary>
+        /// <param name="templateId">The name of the response template.</param>
+        /// <param name="locale">The locale for the response template.</param>
+        /// <param name="tokens">StringDictionary of tokens to replace in the response.</param>
+        /// <returns>An Activity.</returns>
+        public Activity GetResponse(
+            string templateId,
+            string locale,
+            StringDictionary tokens = null)
+        {
+            var template = GetResponseTemplate(templateId, locale);
+
+            // create the response the data items
+            return ParseResponse(template, tokens);
+        }
+
+        /// <summary>
         /// Get a response with an Adaptive Card attachment.
         /// </summary>
         /// <param name="card">The card to add to the response.</param>


### PR DESCRIPTION
- Allow ResponseManager to create a response using a specific locale
- Make MultiProviderAuthDialog create a new auth dialog by each
configured locale

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
