### PR TITLE
Fix Virtual Assistant's YAML compatibility issues

### DIFF
--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
@@ -60,7 +60,8 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy VA'
   inputs:
-    SourceFolder: '$(System.DefaultWorkingDirectory)\templates\Virtual-Assistant-Template\csharp\Sample\VirtualAssistantSample'
+    # if your working directory is not root, you may change the following path
+    SourceFolder: '$(System.DefaultWorkingDirectory)\VirtualAssistantSample'
     Contents: '**\*'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\VA'
 

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
@@ -57,7 +57,7 @@ steps:
     summaryFileLocation: '$(Build.SourcesDirectory)\VirtualAssistantSample.Tests\coverage.cobertura.xml'
     reportDirectory: '$(Build.SourcesDirectory)\VirtualAssistantSample.Tests'
 
- - task: CopyFiles@2
+- task: CopyFiles@2
   displayName: 'Copy VA'
   inputs:
     SourceFolder: '$(System.DefaultWorkingDirectory)\templates\Virtual-Assistant-Template\csharp\Sample\VirtualAssistantSample'

--- a/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
+++ b/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml
@@ -1,31 +1,28 @@
 # specific branch build
 trigger:
-  branches:  
+  branches:
     include:
     - master
     - feature/*
-  
+
 pool:
-   name: Hosted VS2017
-   demands:
-    - msbuild
-    - visualstudio
+   vmimage: 'windows-2019'
 
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
 steps:
-- task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.2.100'
+- task: DotNetCoreInstaller@2
+  displayName: 'Use .NET Core sdk 3.1'
   inputs:
-    version: 2.2.100
+    version: 3.1.x
   continueOnError: true
 
 - task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
+  displayName: 'Use NuGet 5.3.0'
   inputs:
-    versionSpec: 4.9.1
+    versionSpec: 5.3.0
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'

--- a/templates/csharp/VA/VA/Pipeline/VirtualAssistantSample.yml
+++ b/templates/csharp/VA/VA/Pipeline/VirtualAssistantSample.yml
@@ -1,31 +1,28 @@
 # specific branch build
 trigger:
-  branches:  
+  branches:
     include:
     - master
     - feature/*
-  
+
 pool:
-   name: Hosted VS2017
-   demands:
-    - msbuild
-    - visualstudio
+   vmimage: 'windows-2019'
 
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 
 steps:
-- task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.2.100'
+- task: DotNetCoreInstaller@2
+  displayName: 'Use .NET Core sdk 3.1'
   inputs:
-    version: 2.2.100
+    version: 3.1.x
   continueOnError: true
 
 - task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
+  displayName: 'Use NuGet 5.3.0'
   inputs:
-    versionSpec: 4.9.1
+    versionSpec: 5.3.0
 
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
@@ -60,10 +57,11 @@ steps:
     summaryFileLocation: '$(Build.SourcesDirectory)\$safeprojectname$.Tests\coverage.cobertura.xml'
     reportDirectory: '$(Build.SourcesDirectory)\$safeprojectname$.Tests'
 
- - task: CopyFiles@2
+- task: CopyFiles@2
   displayName: 'Copy VA'
   inputs:
-    SourceFolder: '$(System.DefaultWorkingDirectory)\templates\Virtual-Assistant-Template\csharp\Sample\VirtualAssistantSample'
+    # if your working directory is not root, you may change the following path
+    SourceFolder: '$(System.DefaultWorkingDirectory)\$safeprojectname$'
     Contents: '**\*'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\VA'
 


### PR DESCRIPTION
Fixes MS3833

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Pipeline created using the provided [VirtualAssistantSample.yml](https://github.com/microsoft/botframework-solutions/blob/master/samples/csharp/assistants/virtual-assistant/VirtualAssistantSample/Pipeline/VirtualAssistantSample.yml) file would fail due to being outdated, as reported in issue MS3833.

Pipeline passes with the applied changes, as shown in the picture.
![image](https://user-images.githubusercontent.com/20074735/125841942-f048e589-bd8a-4f44-b1c8-c3d1a5736395.png)


### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
The following changes were applied:

- NuGet Tool Installer task NuGet version was updated from version 4.9.1 to 5.3.0.
- DotNet Core Installer task was updated to install version 3.1 of NET Core, and the task itself was also upgraded to version 2.
- Build tool were upgraded for NET Core 3.1 by updating the pool version to 'windows-2019'.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
